### PR TITLE
Develop minimum rate stream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ pkg_check_modules(swscale libswscale REQUIRED)
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package()
 
-set(CMAKE_BUILD_TYPE Debug )
-
 ###########
 ## Build ##
 ###########

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ pkg_check_modules(swscale libswscale REQUIRED)
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package()
 
+set(CMAKE_BUILD_TYPE Debug )
+
 ###########
 ## Build ##
 ###########

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -24,9 +24,13 @@ public:
   {
     return topic_;
   }
-  ;
+
+  /**
+   * Restreams the last received image frame if older than max_age.
+   */
+  virtual void restreamFrame(double max_age);
 protected:
-  virtual void sendImage(const cv::Mat &, const ros::Time &time) = 0;
+  virtual void sendImage(const cv::Mat &, const ros::WallTime &time) = 0;
 
   virtual void initialize(const cv::Mat &);
 
@@ -38,6 +42,10 @@ protected:
   int output_width_;
   int output_height_;
   bool invert_;
+  ros::WallTime last_frame;
+  cv::Mat output_size_image;
+  boost::mutex send_mutex_;
+
 private:
   image_transport::ImageTransport it_;
   bool initialized_;

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -16,6 +16,8 @@ public:
   ImageStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
                 image_transport::ImageTransport it);
 
+  virtual ~ImageStreamer();
+
   void start();
 
   bool isInactive();

--- a/include/web_video_server/jpeg_streamers.h
+++ b/include/web_video_server/jpeg_streamers.h
@@ -14,7 +14,7 @@ class MjpegStreamer : public ImageStreamer
 public:
   MjpegStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
                 image_transport::ImageTransport it);
-
+  ~MjpegStreamer();
 protected:
   virtual void sendImage(const cv::Mat &, const ros::WallTime &time);
 
@@ -38,6 +38,7 @@ public:
   JpegSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
                        async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it);
 
+  ~JpegSnapshotStreamer();
 protected:
   virtual void sendImage(const cv::Mat &, const ros::WallTime &time);
 

--- a/include/web_video_server/jpeg_streamers.h
+++ b/include/web_video_server/jpeg_streamers.h
@@ -16,7 +16,7 @@ public:
                 image_transport::ImageTransport it);
 
 protected:
-  virtual void sendImage(const cv::Mat &, const ros::Time &time);
+  virtual void sendImage(const cv::Mat &, const ros::WallTime &time);
 
 private:
   int quality_;
@@ -39,7 +39,7 @@ public:
                        async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it);
 
 protected:
-  virtual void sendImage(const cv::Mat &, const ros::Time &time);
+  virtual void sendImage(const cv::Mat &, const ros::WallTime &time);
 
 private:
   int quality_;

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -31,7 +31,7 @@ public:
 
 protected:
   virtual void initializeEncoder();
-  virtual void sendImage(const cv::Mat&, const ros::Time& time);
+  virtual void sendImage(const cv::Mat&, const ros::WallTime& time);
   virtual void initialize(const cv::Mat&);
   AVOutputFormat* output_format_;
   AVFormatContext* format_context_;
@@ -44,7 +44,7 @@ private:
   AVPicture* picture_;
   AVPicture* tmp_picture_;
   struct SwsContext* sws_context_;
-  ros::Time first_image_timestamp_;
+  ros::WallTime first_image_timestamp_;
   boost::mutex encode_mutex_;
 
   std::string format_name_;

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -29,6 +29,7 @@ public:
 
   ~LibavStreamer();
 
+  static void SetupAVLibrary();
 protected:
   virtual void initializeEncoder();
   virtual void sendImage(const cv::Mat&, const ros::WallTime& time);

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -49,12 +49,14 @@ public:
                            async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
 private:
+  void restreamFrames( double max_age );
   void cleanup_inactive_streams();
 
   ros::NodeHandle nh_;
   image_transport::ImageTransport image_transport_;
   ros::Timer cleanup_timer_;
   int ros_threads_;
+  double publish_rate_;
   boost::shared_ptr<async_web_server_cpp::HttpServer> server_;
   async_web_server_cpp::HttpRequestHandlerGroup handler_group_;
 

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -98,6 +98,7 @@ void ImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr &msg)
       cv::flip(img, img, true);
     }
 
+    boost::mutex::scoped_lock lock(send_mutex_); // protects output_size_image
     if (output_width_ != input_width || output_height_ != input_height)
     {
       cv::Mat img_resized;
@@ -115,7 +116,7 @@ void ImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr &msg)
       initialize(output_size_image);
       initialized_ = true;
     }
-    boost::mutex::scoped_lock lock(send_mutex_);
+
     last_frame = ros::WallTime::now();
     sendImage(output_size_image, last_frame );
 

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -14,6 +14,10 @@ ImageStreamer::ImageStreamer(const async_web_server_cpp::HttpRequest &request,
   invert_ = request.has_query_param("invert");
 }
 
+ImageStreamer::~ImageStreamer()
+{
+}
+
 void ImageStreamer::start()
 {
   image_sub_ = it_.subscribe(topic_, 1, &ImageStreamer::imageCallback, this);

--- a/src/jpeg_streamers.cpp
+++ b/src/jpeg_streamers.cpp
@@ -18,6 +18,12 @@ MjpegStreamer::MjpegStreamer(const async_web_server_cpp::HttpRequest &request,
   connection->write("--boundarydonotcross \r\n");
 }
 
+MjpegStreamer::~MjpegStreamer()
+{
+  this->inactive_ = true;
+  boost::mutex::scoped_lock lock(send_mutex_); // protects sendImage.
+}
+
 void MjpegStreamer::sendImage(const cv::Mat &img, const ros::WallTime &time)
 {
   std::vector<int> encode_params;
@@ -63,6 +69,14 @@ JpegSnapshotStreamer::JpegSnapshotStreamer(const async_web_server_cpp::HttpReque
 {
   quality_ = request.get_query_param_value_or_default<int>("quality", 95);
 }
+
+JpegSnapshotStreamer::~JpegSnapshotStreamer()
+{
+  this->inactive_ = true;
+  boost::mutex::scoped_lock lock(send_mutex_); // protects sendImage.
+}
+
+
 
 void JpegSnapshotStreamer::sendImage(const cv::Mat &img, const ros::WallTime &time)
 {

--- a/src/jpeg_streamers.cpp
+++ b/src/jpeg_streamers.cpp
@@ -18,7 +18,7 @@ MjpegStreamer::MjpegStreamer(const async_web_server_cpp::HttpRequest &request,
   connection->write("--boundarydonotcross \r\n");
 }
 
-void MjpegStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
+void MjpegStreamer::sendImage(const cv::Mat &img, const ros::WallTime &time)
 {
   std::vector<int> encode_params;
   encode_params.push_back(CV_IMWRITE_JPEG_QUALITY);
@@ -64,7 +64,7 @@ JpegSnapshotStreamer::JpegSnapshotStreamer(const async_web_server_cpp::HttpReque
   quality_ = request.get_query_param_value_or_default<int>("quality", 95);
 }
 
-void JpegSnapshotStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
+void JpegSnapshotStreamer::sendImage(const cv::Mat &img, const ros::WallTime &time)
 {
   std::vector<int> encode_params;
   encode_params.push_back(CV_IMWRITE_JPEG_QUALITY);

--- a/src/jpeg_streamers.cpp
+++ b/src/jpeg_streamers.cpp
@@ -41,6 +41,7 @@ void MjpegStreamer::sendImage(const cv::Mat &img, const ros::WallTime &time)
   headers->push_back(async_web_server_cpp::HttpHeader("X-Timestamp", stamp));
   headers->push_back(
       async_web_server_cpp::HttpHeader("Content-Length", boost::lexical_cast<std::string>(encoded_buffer.size())));
+  headers->push_back(async_web_server_cpp::HttpHeader("Access-Control-Allow-Origin", "*"));
   connection_->write(async_web_server_cpp::HttpReply::to_buffers(*headers), headers);
   connection_->write_and_clear(encoded_buffer);
   connection_->write("\r\n--boundarydonotcross \r\n");

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -64,6 +64,8 @@ LibavStreamer::LibavStreamer(const async_web_server_cpp::HttpRequest &request,
 
 LibavStreamer::~LibavStreamer()
 {
+  this->inactive_ = true;
+  boost::mutex::scoped_lock lock(send_mutex_); // protects all structures below when send is still in progress.
   if (codec_context_)
     avcodec_close(codec_context_);
   if (frame_)

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -58,6 +58,10 @@ LibavStreamer::LibavStreamer(const async_web_server_cpp::HttpRequest &request,
   qmax_ = request.get_query_param_value_or_default<int>("qmax", 42);
   gop_ = request.get_query_param_value_or_default<int>("gop", 250);
 
+}
+
+void LibavStreamer::SetupAVLibrary()
+{
   av_lockmgr_register(&ffmpeg_boost_mutex_lock_manager);
   av_register_all();
 }
@@ -154,7 +158,7 @@ void LibavStreamer::initialize(const cv::Mat &img)
   codec_context_->time_base.den = 1;
   codec_context_->gop_size = gop_;
   codec_context_->pix_fmt = PIX_FMT_YUV420P;
-  codec_context_->max_b_frames = 1;
+  codec_context_->max_b_frames = 0;
 
   // Quality settings
   codec_context_->qmin = qmin_;

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -56,7 +56,7 @@ LibavStreamer::LibavStreamer(const async_web_server_cpp::HttpRequest &request,
   bitrate_ = request.get_query_param_value_or_default<int>("bitrate", 100000);
   qmin_ = request.get_query_param_value_or_default<int>("qmin", 1);
   qmax_ = request.get_query_param_value_or_default<int>("qmax", 40);
-  gop_ = request.get_query_param_value_or_default<int>("gop", 5);
+  gop_ = request.get_query_param_value_or_default<int>("gop", 64);
 
 }
 
@@ -153,13 +153,13 @@ void LibavStreamer::initialize(const cv::Mat &img)
   codec_context_->delay = 0;
 
   video_stream_->time_base.num = 1;
-  video_stream_->time_base.den = 10;
+  video_stream_->time_base.den = 1000;
 
   codec_context_->time_base.num = 1;
-  codec_context_->time_base.den = 10;
+  codec_context_->time_base.den = 1;
   codec_context_->gop_size = gop_;
   codec_context_->pix_fmt = PIX_FMT_YUV420P;
-  codec_context_->max_b_frames = 0;
+  codec_context_->max_b_frames = 1;
 
   // Quality settings
   codec_context_->qmin = qmin_;

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -323,8 +323,10 @@ void LibavStreamer::sendImage(const cv::Mat &img, const ros::WallTime &time)
   try {
     connection_->write_and_clear(encoded_frame);
   } catch (boost::system::system_error& e) {
-    // probably a broken pipe.
-    throw std::runtime_error(std::string("Error on socket connection: ") + e.what() );
+    // probably a broken pipe. Bail out.
+    ROS_DEBUG("system_error exception: %s", e.what());
+    inactive_ = true;
+    return;
   }
 }
 

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -54,9 +54,9 @@ LibavStreamer::LibavStreamer(const async_web_server_cpp::HttpRequest &request,
 {
 
   bitrate_ = request.get_query_param_value_or_default<int>("bitrate", 100000);
-  qmin_ = request.get_query_param_value_or_default<int>("qmin", 10);
-  qmax_ = request.get_query_param_value_or_default<int>("qmax", 42);
-  gop_ = request.get_query_param_value_or_default<int>("gop", 250);
+  qmin_ = request.get_query_param_value_or_default<int>("qmin", 1);
+  qmax_ = request.get_query_param_value_or_default<int>("qmax", 40);
+  gop_ = request.get_query_param_value_or_default<int>("gop", 5);
 
 }
 
@@ -142,6 +142,7 @@ void LibavStreamer::initialize(const cv::Mat &img)
   codec_context_ = video_stream_->codec;
 
   // Set options
+  // calls av_opt_set_defaults internally:
   avcodec_get_context_defaults3(codec_context_, codec_);
 
   codec_context_->codec_id = output_format_->video_codec;
@@ -152,10 +153,10 @@ void LibavStreamer::initialize(const cv::Mat &img)
   codec_context_->delay = 0;
 
   video_stream_->time_base.num = 1;
-  video_stream_->time_base.den = 1000;
+  video_stream_->time_base.den = 10;
 
   codec_context_->time_base.num = 1;
-  codec_context_->time_base.den = 1;
+  codec_context_->time_base.den = 10;
   codec_context_->gop_size = gop_;
   codec_context_->pix_fmt = PIX_FMT_YUV420P;
   codec_context_->max_b_frames = 0;
@@ -292,7 +293,7 @@ void LibavStreamer::sendImage(const cv::Mat &img, const ros::WallTime &time)
 
     double seconds = (time - first_image_timestamp_).toSec();
     // Encode video at 1/0.95 to minimize delay
-    pkt.pts = (int64_t)(seconds / av_q2d(video_stream_->time_base) * 0.95);
+    pkt.pts = (int64_t)(seconds / av_q2d(video_stream_->time_base) * 1.0);
     if (pkt.pts <= 0)
       pkt.pts = 1;
     pkt.dts = AV_NOPTS_VALUE;

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -320,14 +320,7 @@ void LibavStreamer::sendImage(const cv::Mat &img, const ros::WallTime &time)
 
   av_free_packet(&pkt);
 
-  try {
-    connection_->write_and_clear(encoded_frame);
-  } catch (boost::system::system_error& e) {
-    // probably a broken pipe. Bail out.
-    ROS_DEBUG("system_error exception: %s", e.what());
-    inactive_ = true;
-    return;
-  }
+  connection_->write_and_clear(encoded_frame);
 }
 
 LibavStreamerType::LibavStreamerType(const std::string &format_name, const std::string &codec_name,

--- a/src/vp8_streamer.cpp
+++ b/src/vp8_streamer.cpp
@@ -54,7 +54,7 @@ void Vp8Streamer::initializeEncoder()
   typedef std::map<std::string, std::string> AvOptMap;
   AvOptMap av_opt_map;
   av_opt_map["quality"] = quality_;
-  av_opt_map["deadline"] = "1";
+  //av_opt_map["deadline"] = "1";
   av_opt_map["auto-alt-ref"] = "0";
   av_opt_map["lag-in-frames"] = "1";
   av_opt_map["rc_lookahead"] = "1";
@@ -65,7 +65,7 @@ void Vp8Streamer::initializeEncoder()
   {
     av_opt_set(codec_context_->priv_data, itr->first.c_str(), itr->second.c_str(), 0);
   }
-
+#if 0
   // Buffering settings
   int bufsize = 10;
   codec_context_->rc_buffer_size = bufsize;
@@ -74,7 +74,8 @@ void Vp8Streamer::initializeEncoder()
   av_opt_set_int(codec_context_->priv_data, "buf-initial", bufsize, 0);
   av_opt_set_int(codec_context_->priv_data, "buf-optimal", bufsize, 0);
   codec_context_->rc_buffer_aggressivity = 0.5;
-  codec_context_->frame_skip_threshold = 10;
+  codec_context_->frame_skip_threshold = 2;
+#endif
 }
 
 Vp8StreamerType::Vp8StreamerType() :

--- a/src/vp8_streamer.cpp
+++ b/src/vp8_streamer.cpp
@@ -54,11 +54,9 @@ void Vp8Streamer::initializeEncoder()
   typedef std::map<std::string, std::string> AvOptMap;
   AvOptMap av_opt_map;
   av_opt_map["quality"] = quality_;
-  //av_opt_map["deadline"] = "1";
+  av_opt_map["deadline"] = "1";
   av_opt_map["auto-alt-ref"] = "0";
-  av_opt_map["lag-in-frames"] = "1";
-  av_opt_map["rc_lookahead"] = "1";
-  av_opt_map["drop_frame"] = "1";
+  av_opt_map["lag-in-frames"] = "1"; // was: rc_lookahead
   av_opt_map["error-resilient"] = "1";
 
   for (AvOptMap::iterator itr = av_opt_map.begin(); itr != av_opt_map.end(); ++itr)

--- a/src/vp8_streamer.cpp
+++ b/src/vp8_streamer.cpp
@@ -74,7 +74,7 @@ void Vp8Streamer::initializeEncoder()
   av_opt_set_int(codec_context_->priv_data, "buf-initial", bufsize, 0);
   av_opt_set_int(codec_context_->priv_data, "buf-optimal", bufsize, 0);
   codec_context_->rc_buffer_aggressivity = 0.5;
-  codec_context_->frame_skip_threshold = 2;
+  codec_context_->frame_skip_threshold = 10;
 }
 
 Vp8StreamerType::Vp8StreamerType() :

--- a/src/vp8_streamer.cpp
+++ b/src/vp8_streamer.cpp
@@ -74,7 +74,7 @@ void Vp8Streamer::initializeEncoder()
   av_opt_set_int(codec_context_->priv_data, "buf-initial", bufsize, 0);
   av_opt_set_int(codec_context_->priv_data, "buf-optimal", bufsize, 0);
   codec_context_->rc_buffer_aggressivity = 0.5;
-  codec_context_->frame_skip_threshold = 10;
+  codec_context_->frame_skip_threshold = 2;
 }
 
 Vp8StreamerType::Vp8StreamerType() :

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -44,6 +44,8 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
   private_nh.param("ros_threads", ros_threads_, 2);
   private_nh.param("publish_rate", publish_rate_, -1.0);
 
+  // required single-threaded, once-only init:
+  LibavStreamer::SetupAVLibrary();
   stream_types_["mjpeg"] = boost::shared_ptr<ImageStreamerType>(new MjpegStreamerType());
   stream_types_["vp8"] = boost::shared_ptr<ImageStreamerType>(new Vp8StreamerType());
 

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -108,7 +108,7 @@ void WebVideoServer::cleanup_inactive_streams()
     while ( itr != image_subscribers_.end() )
     {
       if ( (*itr)->isInactive() ) {
-	ROS_INFO_STREAM("Removed Stream: " << (*itr)->getTopic());
+	ROS_INFO_STREAM("Removing Stream: " << (*itr)->getTopic() << " (streams left: "<< (image_subscribers_.end() - itr ) -1 << ")");
 	image_subscribers_.erase( itr );
 	itr = image_subscribers_.begin();
       }


### PR DESCRIPTION
This is a series of patches to fix #7 but to also support streaming images of nodes that only publish an image once in a while. If nodes don't republish an image, the web_video_server and/or browser get lost and no longer update the video element in the browser.

Finally, it was necessary to modify some of the encoding parameters in order to get a clean video stream at the browser. Some lag seems to be added, it's not clear if this could be improved again.
