### PR TITLE
Add compressedImage

### DIFF
--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -3,6 +3,7 @@
 
 #include <ros/ros.h>
 #include <image_transport/image_transport.h>
+#include <sensor_msgs/CompressedImage.h>
 #include <opencv2/opencv.hpp>
 #include "async_web_server_cpp/http_server.hpp"
 #include "async_web_server_cpp/http_request.hpp"
@@ -27,6 +28,7 @@ public:
   ;
 protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time) = 0;
+  virtual void sendImageCompressed(const cv::Mat &img, const ros::Time &time)=0;
 
   virtual void initialize(const cv::Mat &);
 
@@ -42,6 +44,7 @@ private:
   image_transport::ImageTransport it_;
   bool initialized_;
 
+  void imageCompressCb(const sensor_msgs::CompressedImageConstPtr& msg);
   void imageCallback(const sensor_msgs::ImageConstPtr &msg);
 };
 

--- a/include/web_video_server/jpeg_streamers.h
+++ b/include/web_video_server/jpeg_streamers.h
@@ -16,6 +16,7 @@ public:
                 image_transport::ImageTransport it);
 
 protected:
+  virtual void sendImageCompressed(const cv::Mat &img, const ros::Time &time);
   virtual void sendImage(const cv::Mat &, const ros::Time &time);
 
 private:
@@ -39,6 +40,7 @@ public:
                        async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it);
 
 protected:
+  virtual void sendImageCompressed(const cv::Mat &img, const ros::Time &time);
   virtual void sendImage(const cv::Mat &, const ros::Time &time);
 
 private:

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -32,6 +32,7 @@ public:
 protected:
   virtual void initializeEncoder();
   virtual void sendImage(const cv::Mat&, const ros::Time& time);
+  virtual void sendImageCompressed(const cv::Mat&, const ros::Time& time);
   virtual void initialize(const cv::Mat&);
   AVOutputFormat* output_format_;
   AVFormatContext* format_context_;

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -16,7 +16,24 @@ ImageStreamer::ImageStreamer(const async_web_server_cpp::HttpRequest &request,
 
 void ImageStreamer::start()
 {
-  image_sub_ = it_.subscribe(topic_, 1, &ImageStreamer::imageCallback, this);
+//  image_sub_ = it_.subscribe(topic_, 1, &ImageStreamer::imageCallback, this);
+  ros::NodeHandle nh;
+  ros::Subscriber sub_compress = nh.subscribe<sensor_msgs::CompressedImage>("/usb_cam/image_raw/compressed",
+                                                                    1,
+                                                                    boost::bind(&ImageStreamer::imageCompressCb, this, _1),
+                                                                    ros::VoidPtr(),
+                                                                    ros::TransportHints().tcpNoDelay());  
+
+}
+void ImageStreamer::imageCompressCb(const sensor_msgs::CompressedImageConstPtr& msg)
+{
+    ROS_INFO("ImageStreamer::imageCompressCb");
+
+    cv::Mat compressed;
+    compressed = cv::Mat(1, msg->data.size(), CV_8UC1,
+                            const_cast<unsigned char*>(&msg->data[0]));
+    sendImageCompressed(compressed, msg->header.stamp);
+
 }
 
 void ImageStreamer::initialize(const cv::Mat &)

--- a/src/jpeg_streamers.cpp
+++ b/src/jpeg_streamers.cpp
@@ -18,6 +18,24 @@ MjpegStreamer::MjpegStreamer(const async_web_server_cpp::HttpRequest &request,
   connection->write("--boundarydonotcross \r\n");
 }
 
+void MjpegStreamer::sendImageCompressed(const cv::Mat &img, const ros::Time &time)
+{
+  std::vector<uchar> encoded_buffer(img.begin<uchar>(), img.end<uchar>());
+
+  char stamp[20];
+  sprintf(stamp, "%.06lf", time.toSec());
+  boost::shared_ptr<std::vector<async_web_server_cpp::HttpHeader> > headers(
+      new std::vector<async_web_server_cpp::HttpHeader>());
+  headers->push_back(async_web_server_cpp::HttpHeader("Content-type", "image/jpeg"));
+  headers->push_back(async_web_server_cpp::HttpHeader("X-Timestamp", stamp));
+  headers->push_back(
+      async_web_server_cpp::HttpHeader("Content-Length", boost::lexical_cast<std::string>(encoded_buffer.size())));
+  connection_->write(async_web_server_cpp::HttpReply::to_buffers(*headers), headers);
+  connection_->write_and_clear(encoded_buffer);
+  connection_->write("\r\n--boundarydonotcross \r\n");
+}
+
+
 void MjpegStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
 {
   std::vector<int> encode_params;
@@ -62,6 +80,23 @@ JpegSnapshotStreamer::JpegSnapshotStreamer(const async_web_server_cpp::HttpReque
     ImageStreamer(request, connection, it)
 {
   quality_ = request.get_query_param_value_or_default<int>("quality", 95);
+}
+
+void JpegSnapshotStreamer::sendImageCompressed(const cv::Mat &img, const ros::Time &time)
+{
+  std::vector<uchar> encoded_buffer(img.begin<uchar>(), img.end<uchar>());
+
+  char stamp[20];
+  sprintf(stamp, "%.06lf", time.toSec());
+  async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok).header("Connection", "close").header(
+      "Server", "web_video_server").header("Cache-Control",
+                                           "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0").header(
+      "X-Timestamp", stamp).header("Pragma", "no-cache").header("Content-type", "image/jpeg").header(
+      "Access-Control-Allow-Origin", "*").header("Content-Length",
+                                                 boost::lexical_cast<std::string>(encoded_buffer.size())).write(
+      connection_);
+  connection_->write_and_clear(encoded_buffer);
+  inactive_ = true;
 }
 
 void JpegSnapshotStreamer::sendImage(const cv::Mat &img, const ros::Time &time)

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -230,6 +230,10 @@ void LibavStreamer::initializeEncoder()
 {
 }
 
+void LibavStreamer::sendImageCompressed(const cv::Mat &img, const ros::Time &time)
+{
+
+}
 void LibavStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
 {
   boost::mutex::scoped_lock lock(encode_mutex_);


### PR DESCRIPTION
Hi,

I would like to add a callback to compressedImage, The main idea is to avoid decompress and compress the image every time. I only want to move the image data without processing the image (cv::imencode(...)). But I have some problems when I try to call the callback, The callback is never called. In the following line you can see how I bind the method. https://github.com/erlerobot/web_video_server/blob/develop/src/image_streamer.cpp#L21.

Any ideas are most welcome