### PR TITLE
Adds support for streaming ROS compressed image topics without the need to reencode them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,13 @@ install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
-  - sudo apt-get install python-catkin-pkg python-rosdep ros-groovy-catkin ros-hydro-catkin -qq
+  - sudo apt-get install python-catkin-pkg python-rosdep ros-hydro-catkin ros-hydro-catkin -qq
   - sudo rosdep init
   - rosdep update
   - mkdir -p /tmp/ws/src
   - ln -s `pwd` /tmp/ws/src/package
+  - cd /tmp/ws/src
+  - git clone https://github.com/WPI-RAIL/async_web_server_cpp.git
   - cd /tmp/ws
   - rosdep install --from-paths src --ignore-src --rosdistro hydro -y
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(${PROJECT_NAME}
   src/image_streamer.cpp
   src/libav_streamer.cpp
   src/vp8_streamer.cpp
+  src/multipart_stream.cpp
+  src/ros_compressed_streamer.cpp
   src/jpeg_streamers.cpp)
 
 ## Specify libraries to link a library or executable target against

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -14,7 +14,7 @@ class ImageStreamer
 {
 public:
   ImageStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
-                image_transport::ImageTransport it);
+                ros::NodeHandle& it);
 
   void start();
 
@@ -51,7 +51,7 @@ class ImageStreamerType
 public:
   virtual boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                            async_web_server_cpp::HttpConnectionPtr connection,
-                                                           image_transport::ImageTransport it) = 0;
+                                                           ros::NodeHandle& nh) = 0;
 
   virtual std::string create_viewer(const async_web_server_cpp::HttpRequest &request) = 0;
 };

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -13,12 +13,17 @@ namespace web_video_server
 class ImageStreamer
 {
 public:
-  ImageStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
-                ros::NodeHandle& it);
+  ImageStreamer(const async_web_server_cpp::HttpRequest &request,
+		async_web_server_cpp::HttpConnectionPtr connection,
+		ros::NodeHandle& nh);
 
-  void start();
+  virtual void start() = 0;
 
-  bool isInactive();
+  bool isInactive()
+  {
+    return inactive_;
+  }
+  ;
 
   std::string getTopic()
   {
@@ -26,15 +31,29 @@ public:
   }
   ;
 protected:
+  async_web_server_cpp::HttpConnectionPtr connection_;
+  async_web_server_cpp::HttpRequest request_;
+  ros::NodeHandle nh_;
+  bool inactive_;
+  image_transport::Subscriber image_sub_;
+  std::string topic_;
+};
+
+
+class ImageTransportImageStreamer : public ImageStreamer
+{
+public:
+  ImageTransportImageStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
+			      ros::NodeHandle& nh);
+
+  virtual void start();
+
+protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time) = 0;
 
   virtual void initialize(const cv::Mat &);
 
-  async_web_server_cpp::HttpConnectionPtr connection_;
-  async_web_server_cpp::HttpRequest request_;
-  bool inactive_;
   image_transport::Subscriber image_sub_;
-  std::string topic_;
   int output_width_;
   int output_height_;
   bool invert_;

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -38,6 +38,7 @@ protected:
   int output_width_;
   int output_height_;
   bool invert_;
+  std::string default_transport_;
 private:
   image_transport::ImageTransport it_;
   bool initialized_;

--- a/include/web_video_server/jpeg_streamers.h
+++ b/include/web_video_server/jpeg_streamers.h
@@ -5,11 +5,12 @@
 #include "web_video_server/image_streamer.h"
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"
+#include "web_video_server/multipart_stream.h"
 
 namespace web_video_server
 {
 
-class MjpegStreamer : public ImageStreamer
+class MjpegStreamer : public ImageTransportImageStreamer
 {
 public:
   MjpegStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
@@ -19,6 +20,7 @@ protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time);
 
 private:
+  MultipartStream stream_;
   int quality_;
 };
 
@@ -28,11 +30,10 @@ public:
   boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                    async_web_server_cpp::HttpConnectionPtr connection,
                                                    ros::NodeHandle& nh);
-
   std::string create_viewer(const async_web_server_cpp::HttpRequest &request);
 };
 
-class JpegSnapshotStreamer : public ImageStreamer
+class JpegSnapshotStreamer : public ImageTransportImageStreamer
 {
 public:
   JpegSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,

--- a/include/web_video_server/jpeg_streamers.h
+++ b/include/web_video_server/jpeg_streamers.h
@@ -13,7 +13,7 @@ class MjpegStreamer : public ImageStreamer
 {
 public:
   MjpegStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
-                image_transport::ImageTransport it);
+                ros::NodeHandle& nh);
 
 protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time);
@@ -27,7 +27,7 @@ class MjpegStreamerType : public ImageStreamerType
 public:
   boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                    async_web_server_cpp::HttpConnectionPtr connection,
-                                                   image_transport::ImageTransport it);
+                                                   ros::NodeHandle& nh);
 
   std::string create_viewer(const async_web_server_cpp::HttpRequest &request);
 };
@@ -36,7 +36,7 @@ class JpegSnapshotStreamer : public ImageStreamer
 {
 public:
   JpegSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
-                       async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it);
+                       async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh);
 
 protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time);

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -20,7 +20,7 @@ extern "C"
 namespace web_video_server
 {
 
-class LibavStreamer : public ImageStreamer
+class LibavStreamer : public ImageTransportImageStreamer
 {
 public:
   LibavStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -24,7 +24,7 @@ class LibavStreamer : public ImageStreamer
 {
 public:
   LibavStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
-                image_transport::ImageTransport it, const std::string &format_name, const std::string &codec_name,
+                ros::NodeHandle& nh, const std::string &format_name, const std::string &codec_name,
                 const std::string &content_type);
 
   ~LibavStreamer();
@@ -63,7 +63,7 @@ public:
 
   boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                    async_web_server_cpp::HttpConnectionPtr connection,
-                                                   image_transport::ImageTransport it);
+                                                   ros::NodeHandle& nh);
 
   std::string create_viewer(const async_web_server_cpp::HttpRequest &request);
 

--- a/include/web_video_server/multipart_stream.h
+++ b/include/web_video_server/multipart_stream.h
@@ -1,0 +1,28 @@
+#ifndef MULTIPART_STREAM_H_
+#define MULTIPART_STREAM_H_
+
+#include <ros/ros.h>
+#include <async_web_server_cpp/http_connection.hpp>
+
+namespace web_video_server
+{
+
+class MultipartStream {
+public:
+  MultipartStream(async_web_server_cpp::HttpConnectionPtr& connection, const std::string& boundry="boundarydonotcross");
+
+  void sendInitialHeader();
+  void sendPartHeader(const ros::Time &time, const std::string& type, size_t payload_size);
+  void sendPartFooter();
+  void sendPartAndClear(const ros::Time &time, const std::string& type, std::vector<unsigned char> &data);
+  void sendPart(const ros::Time &time, const std::string& type, const boost::asio::const_buffer &buffer,
+		async_web_server_cpp::HttpConnection::ResourcePtr resource);
+
+private:
+  async_web_server_cpp::HttpConnectionPtr connection_;
+  std::string boundry_;
+};
+
+}
+
+#endif

--- a/include/web_video_server/ros_compressed_streamer.h
+++ b/include/web_video_server/ros_compressed_streamer.h
@@ -1,0 +1,38 @@
+#ifndef ROS_COMPRESSED_STREAMERS_H_
+#define ROS_COMPRESSED_STREAMERS_H_
+
+#include <sensor_msgs/CompressedImage.h>
+#include "web_video_server/image_streamer.h"
+#include "async_web_server_cpp/http_request.hpp"
+#include "async_web_server_cpp/http_connection.hpp"
+#include "web_video_server/multipart_stream.h"
+
+namespace web_video_server
+{
+
+class RosCompressedStreamer : public ImageStreamer
+{
+public:
+  RosCompressedStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
+			ros::NodeHandle& nh);
+  virtual void start();
+
+private:
+  void imageCallback(const sensor_msgs::CompressedImageConstPtr &msg);
+
+  MultipartStream stream_;
+  ros::Subscriber image_sub_;
+};
+
+class RosCompressedStreamerType : public ImageStreamerType
+{
+public:
+  boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
+                                                   async_web_server_cpp::HttpConnectionPtr connection,
+                                                   ros::NodeHandle& nh);
+  std::string create_viewer(const async_web_server_cpp::HttpRequest &request);
+};
+
+}
+
+#endif

--- a/include/web_video_server/vp8_streamer.h
+++ b/include/web_video_server/vp8_streamer.h
@@ -49,7 +49,7 @@ class Vp8Streamer : public LibavStreamer
 {
 public:
   Vp8Streamer(const async_web_server_cpp::HttpRequest& request, async_web_server_cpp::HttpConnectionPtr connection,
-              image_transport::ImageTransport it);
+              ros::NodeHandle& nh);
   ~Vp8Streamer();
 protected:
   virtual void initializeEncoder();
@@ -63,7 +63,7 @@ public:
   Vp8StreamerType();
   virtual boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest& request,
                                                            async_web_server_cpp::HttpConnectionPtr connection,
-                                                           image_transport::ImageTransport it);
+                                                           ros::NodeHandle& nh);
 };
 
 }

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -2,7 +2,6 @@
 #define WEB_VIDEO_SERVER_H_
 
 #include <ros/ros.h>
-#include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 #include <vector>
 #include "web_video_server/image_streamer.h"
@@ -52,7 +51,6 @@ private:
   void cleanup_inactive_streams();
 
   ros::NodeHandle nh_;
-  image_transport::ImageTransport image_transport_;
   ros::Timer cleanup_timer_;
   int ros_threads_;
   int port_;

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -35,16 +35,16 @@ public:
    */
   void spin();
 
-  void handle_stream(const async_web_server_cpp::HttpRequest &request,
+  bool handle_stream(const async_web_server_cpp::HttpRequest &request,
                      async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
-  void handle_stream_viewer(const async_web_server_cpp::HttpRequest &request,
+  bool handle_stream_viewer(const async_web_server_cpp::HttpRequest &request,
                             async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
-  void handle_snapshot(const async_web_server_cpp::HttpRequest &request,
+  bool handle_snapshot(const async_web_server_cpp::HttpRequest &request,
                        async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
-  void handle_list_streams(const async_web_server_cpp::HttpRequest &request,
+  bool handle_list_streams(const async_web_server_cpp::HttpRequest &request,
                            async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
 private:

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -6,26 +6,32 @@ namespace web_video_server
 
 ImageStreamer::ImageStreamer(const async_web_server_cpp::HttpRequest &request,
                              async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
-    request_(request), connection_(connection), it_(nh), inactive_(false), initialized_(false)
+    request_(request), connection_(connection), nh_(nh), inactive_(false)
 {
   topic_ = request.get_query_param_value_or_default("topic", "");
+}
+
+ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_cpp::HttpRequest &request,
+                             async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+  ImageStreamer(request, connection, nh), it_(nh), initialized_(false)
+{
   output_width_ = request.get_query_param_value_or_default<int>("width", -1);
   output_height_ = request.get_query_param_value_or_default<int>("height", -1);
   invert_ = request.has_query_param("invert");
   default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
 }
 
-void ImageStreamer::start()
+void ImageTransportImageStreamer::start()
 {
   image_transport::TransportHints hints(default_transport_);
-  image_sub_ = it_.subscribe(topic_, 1, &ImageStreamer::imageCallback, this, hints);
+  image_sub_ = it_.subscribe(topic_, 1, &ImageTransportImageStreamer::imageCallback, this, hints);
 }
 
-void ImageStreamer::initialize(const cv::Mat &)
+void ImageTransportImageStreamer::initialize(const cv::Mat &)
 {
 }
 
-void ImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr &msg)
+void ImageTransportImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr &msg)
 {
   if (inactive_)
     return;
@@ -120,11 +126,6 @@ void ImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr &msg)
     inactive_ = true;
     return;
   }
-}
-
-bool ImageStreamer::isInactive()
-{
-  return inactive_;
 }
 
 }

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -12,11 +12,13 @@ ImageStreamer::ImageStreamer(const async_web_server_cpp::HttpRequest &request,
   output_width_ = request.get_query_param_value_or_default<int>("width", -1);
   output_height_ = request.get_query_param_value_or_default<int>("height", -1);
   invert_ = request.has_query_param("invert");
+  default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
 }
 
 void ImageStreamer::start()
 {
-  image_sub_ = it_.subscribe(topic_, 1, &ImageStreamer::imageCallback, this);
+  image_transport::TransportHints hints(default_transport_);
+  image_sub_ = it_.subscribe(topic_, 1, &ImageStreamer::imageCallback, this, hints);
 }
 
 void ImageStreamer::initialize(const cv::Mat &)

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -5,8 +5,8 @@ namespace web_video_server
 {
 
 ImageStreamer::ImageStreamer(const async_web_server_cpp::HttpRequest &request,
-                             async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it) :
-    request_(request), connection_(connection), it_(it), inactive_(false), initialized_(false)
+                             async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    request_(request), connection_(connection), it_(nh), inactive_(false), initialized_(false)
 {
   topic_ = request.get_query_param_value_or_default("topic", "");
   output_width_ = request.get_query_param_value_or_default<int>("width", -1);

--- a/src/jpeg_streamers.cpp
+++ b/src/jpeg_streamers.cpp
@@ -6,16 +6,10 @@ namespace web_video_server
 
 MjpegStreamer::MjpegStreamer(const async_web_server_cpp::HttpRequest &request,
                              async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
-    ImageStreamer(request, connection, nh)
+  ImageTransportImageStreamer(request, connection, nh), stream_(connection)
 {
   quality_ = request.get_query_param_value_or_default<int>("quality", 95);
-
-  async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok).header("Connection", "close").header(
-      "Server", "web_video_server").header("Cache-Control",
-                                           "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0").header(
-      "Pragma", "no-cache").header("Content-type", "multipart/x-mixed-replace;boundary=--boundarydonotcross ").header(
-      "Access-Control-Allow-Origin", "*").write(connection);
-  connection->write("--boundarydonotcross \r\n");
+  stream_.sendInitialHeader();
 }
 
 void MjpegStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
@@ -27,17 +21,7 @@ void MjpegStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
   std::vector<uchar> encoded_buffer;
   cv::imencode(".jpeg", img, encoded_buffer, encode_params);
 
-  char stamp[20];
-  sprintf(stamp, "%.06lf", time.toSec());
-  boost::shared_ptr<std::vector<async_web_server_cpp::HttpHeader> > headers(
-      new std::vector<async_web_server_cpp::HttpHeader>());
-  headers->push_back(async_web_server_cpp::HttpHeader("Content-type", "image/jpeg"));
-  headers->push_back(async_web_server_cpp::HttpHeader("X-Timestamp", stamp));
-  headers->push_back(
-      async_web_server_cpp::HttpHeader("Content-Length", boost::lexical_cast<std::string>(encoded_buffer.size())));
-  connection_->write(async_web_server_cpp::HttpReply::to_buffers(*headers), headers);
-  connection_->write_and_clear(encoded_buffer);
-  connection_->write("\r\n--boundarydonotcross \r\n");
+  stream_.sendPartAndClear(time, "image/jpeg", encoded_buffer);
 }
 
 boost::shared_ptr<ImageStreamer> MjpegStreamerType::create_streamer(const async_web_server_cpp::HttpRequest &request,
@@ -59,7 +43,7 @@ std::string MjpegStreamerType::create_viewer(const async_web_server_cpp::HttpReq
 JpegSnapshotStreamer::JpegSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
                                            async_web_server_cpp::HttpConnectionPtr connection,
                                            ros::NodeHandle& nh) :
-    ImageStreamer(request, connection, nh)
+    ImageTransportImageStreamer(request, connection, nh)
 {
   quality_ = request.get_query_param_value_or_default<int>("quality", 95);
 }

--- a/src/jpeg_streamers.cpp
+++ b/src/jpeg_streamers.cpp
@@ -5,8 +5,8 @@ namespace web_video_server
 {
 
 MjpegStreamer::MjpegStreamer(const async_web_server_cpp::HttpRequest &request,
-                             async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it) :
-    ImageStreamer(request, connection, it)
+                             async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    ImageStreamer(request, connection, nh)
 {
   quality_ = request.get_query_param_value_or_default<int>("quality", 95);
 
@@ -42,9 +42,9 @@ void MjpegStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
 
 boost::shared_ptr<ImageStreamer> MjpegStreamerType::create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                                     async_web_server_cpp::HttpConnectionPtr connection,
-                                                                    image_transport::ImageTransport it)
+                                                                    ros::NodeHandle& nh)
 {
-  return boost::shared_ptr<ImageStreamer>(new MjpegStreamer(request, connection, it));
+  return boost::shared_ptr<ImageStreamer>(new MjpegStreamer(request, connection, nh));
 }
 
 std::string MjpegStreamerType::create_viewer(const async_web_server_cpp::HttpRequest &request)
@@ -58,8 +58,8 @@ std::string MjpegStreamerType::create_viewer(const async_web_server_cpp::HttpReq
 
 JpegSnapshotStreamer::JpegSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
                                            async_web_server_cpp::HttpConnectionPtr connection,
-                                           image_transport::ImageTransport it) :
-    ImageStreamer(request, connection, it)
+                                           ros::NodeHandle& nh) :
+    ImageStreamer(request, connection, nh)
 {
   quality_ = request.get_query_param_value_or_default<int>("quality", 95);
 }

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -48,7 +48,7 @@ LibavStreamer::LibavStreamer(const async_web_server_cpp::HttpRequest &request,
                              async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh,
                              const std::string &format_name, const std::string &codec_name,
                              const std::string &content_type) :
-    ImageStreamer(request, connection, nh), output_format_(0), format_context_(0), codec_(0), codec_context_(0), video_stream_(
+    ImageTransportImageStreamer(request, connection, nh), output_format_(0), format_context_(0), codec_(0), codec_context_(0), video_stream_(
         0), frame_(0), picture_(0), tmp_picture_(0), sws_context_(0), first_image_timestamp_(0), format_name_(
         format_name), codec_name_(codec_name), content_type_(content_type)
 {

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -45,10 +45,10 @@ static int ffmpeg_boost_mutex_lock_manager(void **mutex, enum AVLockOp op)
 }
 
 LibavStreamer::LibavStreamer(const async_web_server_cpp::HttpRequest &request,
-                             async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it,
+                             async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh,
                              const std::string &format_name, const std::string &codec_name,
                              const std::string &content_type) :
-    ImageStreamer(request, connection, it), output_format_(0), format_context_(0), codec_(0), codec_context_(0), video_stream_(
+    ImageStreamer(request, connection, nh), output_format_(0), format_context_(0), codec_(0), codec_context_(0), video_stream_(
         0), frame_(0), picture_(0), tmp_picture_(0), sws_context_(0), first_image_timestamp_(0), format_name_(
         format_name), codec_name_(codec_name), content_type_(content_type)
 {
@@ -331,10 +331,10 @@ LibavStreamerType::LibavStreamerType(const std::string &format_name, const std::
 
 boost::shared_ptr<ImageStreamer> LibavStreamerType::create_streamer(const async_web_server_cpp::HttpRequest &request,
                                                                     async_web_server_cpp::HttpConnectionPtr connection,
-                                                                    image_transport::ImageTransport it)
+                                                                    ros::NodeHandle& nh)
 {
   return boost::shared_ptr<ImageStreamer>(
-      new LibavStreamer(request, connection, it, format_name_, codec_name_, content_type_));
+      new LibavStreamer(request, connection, nh, format_name_, codec_name_, content_type_));
 }
 
 std::string LibavStreamerType::create_viewer(const async_web_server_cpp::HttpRequest &request)

--- a/src/multipart_stream.cpp
+++ b/src/multipart_stream.cpp
@@ -1,0 +1,51 @@
+#include "web_video_server/multipart_stream.h"
+#include "async_web_server_cpp/http_reply.hpp"
+
+namespace web_video_server
+{
+
+MultipartStream::MultipartStream(async_web_server_cpp::HttpConnectionPtr& connection, const std::string& boundry)
+  : connection_(connection), boundry_(boundry) {}
+
+void MultipartStream::sendInitialHeader() {
+  async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok).header("Connection", "close").header(
+      "Server", "web_video_server").header("Cache-Control",
+                                           "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0").header(
+      "Pragma", "no-cache").header("Content-type", "multipart/x-mixed-replace;boundary="+boundry_).header(
+      "Access-Control-Allow-Origin", "*").write(connection_);
+  connection_->write("--"+boundry_+"\r\n");
+}
+
+void MultipartStream::sendPartHeader(const ros::Time &time, const std::string& type, size_t payload_size) {
+  char stamp[20];
+  sprintf(stamp, "%.06lf", time.toSec());
+  boost::shared_ptr<std::vector<async_web_server_cpp::HttpHeader> > headers(
+      new std::vector<async_web_server_cpp::HttpHeader>());
+  headers->push_back(async_web_server_cpp::HttpHeader("Content-type", type));
+  headers->push_back(async_web_server_cpp::HttpHeader("X-Timestamp", stamp));
+  headers->push_back(
+      async_web_server_cpp::HttpHeader("Content-Length", boost::lexical_cast<std::string>(payload_size)));
+  connection_->write(async_web_server_cpp::HttpReply::to_buffers(*headers), headers);
+}
+
+void MultipartStream::sendPartFooter() {
+  connection_->write("\r\n--"+boundry_+"\r\n");
+}
+
+void MultipartStream::sendPartAndClear(const ros::Time &time, const std::string& type,
+				       std::vector<unsigned char> &data) {
+  sendPartHeader(time, type, data.size());
+  connection_->write_and_clear(data);
+  sendPartFooter();
+}
+
+void MultipartStream::sendPart(const ros::Time &time, const std::string& type,
+			       const boost::asio::const_buffer &buffer,
+			       async_web_server_cpp::HttpConnection::ResourcePtr resource) {
+  sendPartHeader(time, type, boost::asio::buffer_size(buffer));
+  connection_->write(buffer, resource);
+  sendPartFooter();
+}
+
+
+}

--- a/src/ros_compressed_streamer.cpp
+++ b/src/ros_compressed_streamer.cpp
@@ -1,0 +1,73 @@
+#include "web_video_server/ros_compressed_streamer.h"
+
+namespace web_video_server
+{
+
+RosCompressedStreamer::RosCompressedStreamer(const async_web_server_cpp::HttpRequest &request,
+                             async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+  ImageStreamer(request, connection, nh), stream_(connection)
+{
+  stream_.sendInitialHeader();
+}
+
+void RosCompressedStreamer::start() {
+  std::string compressed_topic = topic_ + "/compressed";
+  image_sub_ = nh_.subscribe(compressed_topic, 1, &RosCompressedStreamer::imageCallback, this);
+}
+
+void RosCompressedStreamer::imageCallback(const sensor_msgs::CompressedImageConstPtr &msg) {
+  try {
+    std::string content_type;
+    if(msg->format.find("jpeg") != std::string::npos) {
+      content_type = "image/jpeg";
+    }
+    else if(msg->format.find("png") != std::string::npos) {
+      content_type = "image/png";
+    }
+    else {
+      ROS_WARN_STREAM("Unknown ROS compressed image format: " << msg->format);
+      return;
+    }
+
+    stream_.sendPart(msg->header.stamp, content_type, boost::asio::buffer(msg->data), msg);
+  }
+  catch (boost::system::system_error &e)
+  {
+    // happens when client disconnects
+    ROS_DEBUG("system_error exception: %s", e.what());
+    inactive_ = true;
+    return;
+  }
+  catch (std::exception &e)
+  {
+    ROS_ERROR_THROTTLE(30, "exception: %s", e.what());
+    inactive_ = true;
+    return;
+  }
+  catch (...)
+  {
+    ROS_ERROR_THROTTLE(30, "exception");
+    inactive_ = true;
+    return;
+  }
+}
+
+
+boost::shared_ptr<ImageStreamer> RosCompressedStreamerType::create_streamer(const async_web_server_cpp::HttpRequest &request,
+										 async_web_server_cpp::HttpConnectionPtr connection,
+										 ros::NodeHandle& nh)
+{
+  return boost::shared_ptr<ImageStreamer>(new RosCompressedStreamer(request, connection, nh));
+}
+
+std::string RosCompressedStreamerType::create_viewer(const async_web_server_cpp::HttpRequest &request)
+{
+  std::stringstream ss;
+  ss << "<img src=\"/stream?";
+  ss << request.query;
+  ss << "\"></img>";
+  return ss.str();
+}
+
+
+}

--- a/src/vp8_streamer.cpp
+++ b/src/vp8_streamer.cpp
@@ -40,8 +40,8 @@ namespace web_video_server
 {
 
 Vp8Streamer::Vp8Streamer(const async_web_server_cpp::HttpRequest& request,
-                         async_web_server_cpp::HttpConnectionPtr connection, image_transport::ImageTransport it) :
-    LibavStreamer(request, connection, it, "webm", "libvpx", "video/webm")
+                         async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    LibavStreamer(request, connection, nh, "webm", "libvpx", "video/webm")
 {
   quality_ = request.get_query_param_value_or_default("quality", "realtime");
 }
@@ -84,9 +84,9 @@ Vp8StreamerType::Vp8StreamerType() :
 
 boost::shared_ptr<ImageStreamer> Vp8StreamerType::create_streamer(const async_web_server_cpp::HttpRequest& request,
                                                                   async_web_server_cpp::HttpConnectionPtr connection,
-                                                                  image_transport::ImageTransport it)
+                                                                  ros::NodeHandle& nh)
 {
-  return boost::shared_ptr<ImageStreamer>(new Vp8Streamer(request, connection, it));
+  return boost::shared_ptr<ImageStreamer>(new Vp8Streamer(request, connection, nh));
 }
 
 }

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -16,7 +16,7 @@ namespace web_video_server
 
 static bool __verbose;
 
-static void ros_connection_logger(async_web_server_cpp::HttpServerRequestHandler forward,
+static bool ros_connection_logger(async_web_server_cpp::HttpServerRequestHandler forward,
                                   const async_web_server_cpp::HttpRequest &request,
                                   async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                   const char* end)
@@ -99,7 +99,7 @@ void WebVideoServer::cleanup_inactive_streams()
   }
 }
 
-void WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &request,
+bool WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &request,
                                    async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                    const char* end)
 {
@@ -116,9 +116,10 @@ void WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &requ
     async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found)(request, connection, begin,
                                                                                              end);
   }
+  return true;
 }
 
-void WebVideoServer::handle_snapshot(const async_web_server_cpp::HttpRequest &request,
+bool WebVideoServer::handle_snapshot(const async_web_server_cpp::HttpRequest &request,
                                      async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                      const char* end)
 {
@@ -127,9 +128,10 @@ void WebVideoServer::handle_snapshot(const async_web_server_cpp::HttpRequest &re
 
   boost::mutex::scoped_lock lock(subscriber_mutex_);
   image_subscribers_.push_back(streamer);
+  return true;
 }
 
-void WebVideoServer::handle_stream_viewer(const async_web_server_cpp::HttpRequest &request,
+bool WebVideoServer::handle_stream_viewer(const async_web_server_cpp::HttpRequest &request,
                                           async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                           const char* end)
 {
@@ -153,9 +155,10 @@ void WebVideoServer::handle_stream_viewer(const async_web_server_cpp::HttpReques
     async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found)(request, connection, begin,
                                                                                              end);
   }
+  return true;
 }
 
-void WebVideoServer::handle_list_streams(const async_web_server_cpp::HttpRequest &request,
+bool WebVideoServer::handle_list_streams(const async_web_server_cpp::HttpRequest &request,
                                          async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                          const char* end)
 {
@@ -224,6 +227,7 @@ void WebVideoServer::handle_list_streams(const async_web_server_cpp::HttpRequest
     connection->write("</li>");
   }
   connection->write("</ul></body></html>");
+  return true;
 }
 
 }

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -6,6 +6,7 @@
 #include <opencv2/opencv.hpp>
 
 #include "web_video_server/web_video_server.h"
+#include "web_video_server/ros_compressed_streamer.h"
 #include "web_video_server/jpeg_streamers.h"
 #include "web_video_server/vp8_streamer.h"
 #include "async_web_server_cpp/http_reply.hpp"
@@ -51,6 +52,7 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
   private_nh.param("ros_threads", ros_threads_, 2);
 
   stream_types_["mjpeg"] = boost::shared_ptr<ImageStreamerType>(new MjpegStreamerType());
+  stream_types_["ros_compressed"] = boost::shared_ptr<ImageStreamerType>(new RosCompressedStreamerType());
   stream_types_["vp8"] = boost::shared_ptr<ImageStreamerType>(new Vp8StreamerType());
 
   handler_group_.addHandlerForPath("/", boost::bind(&WebVideoServer::handle_list_streams, this, _1, _2, _3, _4));

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -35,7 +35,7 @@ static void ros_connection_logger(async_web_server_cpp::HttpServerRequestHandler
 }
 
 WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh) :
-    nh_(nh), image_transport_(nh), handler_group_(
+    nh_(nh), handler_group_(
         async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found))
 {
   cleanup_timer_ = nh.createTimer(ros::Duration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
@@ -104,8 +104,7 @@ void WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &requ
   std::string type = request.get_query_param_value_or_default("type", "mjpeg");
   if (stream_types_.find(type) != stream_types_.end())
   {
-    boost::shared_ptr<ImageStreamer> streamer = stream_types_[type]->create_streamer(request, connection,
-                                                                                     image_transport_);
+    boost::shared_ptr<ImageStreamer> streamer = stream_types_[type]->create_streamer(request, connection, nh_);
     streamer->start();
     boost::mutex::scoped_lock lock(subscriber_mutex_);
     image_subscribers_.push_back(streamer);
@@ -121,7 +120,7 @@ void WebVideoServer::handle_snapshot(const async_web_server_cpp::HttpRequest &re
                                      async_web_server_cpp::HttpConnectionPtr connection, const char* begin,
                                      const char* end)
 {
-  boost::shared_ptr<ImageStreamer> streamer(new JpegSnapshotStreamer(request, connection, image_transport_));
+  boost::shared_ptr<ImageStreamer> streamer(new JpegSnapshotStreamer(request, connection, nh_));
   streamer->start();
 
   boost::mutex::scoped_lock lock(subscriber_mutex_);


### PR DESCRIPTION
This also adds support for an updated API in async_web_server_cpp and requires WPI-RAIL/async_web_server_cpp#5