### PR TITLE
Update for Ubuntu 16.04 and FFmpeg 2.8.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(${PROJECT_NAME}
   src/image_streamer.cpp
   src/libav_streamer.cpp
   src/vp8_streamer.cpp
+  src/h264_streamer.cpp
+  src/vp9_streamer.cpp
   src/multipart_stream.cpp
   src/ros_compressed_streamer.cpp
   src/jpeg_streamers.cpp)

--- a/include/web_video_server/h264_streamer.h
+++ b/include/web_video_server/h264_streamer.h
@@ -1,0 +1,35 @@
+#ifndef H264_STREAMERS_H_
+#define H264_STREAMERS_H_
+
+#include <image_transport/image_transport.h>
+#include "web_video_server/libav_streamer.h"
+#include "async_web_server_cpp/http_request.hpp"
+#include "async_web_server_cpp/http_connection.hpp"
+
+namespace web_video_server
+{
+
+class H264Streamer : public LibavStreamer
+{
+public:
+  H264Streamer(const async_web_server_cpp::HttpRequest& request, async_web_server_cpp::HttpConnectionPtr connection,
+              ros::NodeHandle& nh);
+  ~H264Streamer();
+protected:
+  virtual void initializeEncoder();
+  std::string preset_;
+};
+
+class H264StreamerType : public LibavStreamerType
+{
+public:
+  H264StreamerType();
+  virtual boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                           async_web_server_cpp::HttpConnectionPtr connection,
+                                                           ros::NodeHandle& nh);
+};
+
+}
+
+#endif
+

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -39,10 +39,11 @@ protected:
   AVCodecContext* codec_context_;
   AVStream* video_stream_;
 
+  AVDictionary* opt_;   // container format options
+
 private:
   AVFrame* frame_;
-  AVPicture* picture_;
-  AVPicture* tmp_picture_;
+  AVFrame* bgr_frame_;
   struct SwsContext* sws_context_;
   ros::Time first_image_timestamp_;
   boost::mutex encode_mutex_;
@@ -50,10 +51,8 @@ private:
   std::string format_name_;
   std::string codec_name_;
   std::string content_type_;
-  int bitrate_;
-  int qmin_;
-  int qmax_;
-  int gop_;
+
+  uint8_t* io_buffer_;  // custom IO buffer
 };
 
 class LibavStreamerType : public ImageStreamerType

--- a/include/web_video_server/vp8_streamer.h
+++ b/include/web_video_server/vp8_streamer.h
@@ -53,8 +53,12 @@ public:
   ~Vp8Streamer();
 protected:
   virtual void initializeEncoder();
-private:
+  // codec options
   std::string quality_;
+  int bitrate_;
+  int qmin_;
+  int qmax_;
+  int gop_;
 };
 
 class Vp8StreamerType : public LibavStreamerType

--- a/include/web_video_server/vp9_streamer.h
+++ b/include/web_video_server/vp9_streamer.h
@@ -1,0 +1,33 @@
+#ifndef VP9_STREAMERS_H_
+#define VP9_STREAMERS_H_
+
+#include <image_transport/image_transport.h>
+#include "web_video_server/libav_streamer.h"
+#include "async_web_server_cpp/http_request.hpp"
+#include "async_web_server_cpp/http_connection.hpp"
+
+namespace web_video_server
+{
+
+class Vp9Streamer : public LibavStreamer
+{
+public:
+  Vp9Streamer(const async_web_server_cpp::HttpRequest& request, async_web_server_cpp::HttpConnectionPtr connection,
+              ros::NodeHandle& nh);
+  ~Vp9Streamer();
+protected:
+  virtual void initializeEncoder();
+};
+
+class Vp9StreamerType : public LibavStreamerType
+{
+public:
+  Vp9StreamerType();
+  virtual boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                           async_web_server_cpp::HttpConnectionPtr connection,
+                                                           ros::NodeHandle& nh);
+};
+
+}
+
+#endif

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -1,6 +1,6 @@
 /**
 \mainpage
 
-\b A ROS Node to Stream Image Topics Via multiple formats including MJPEG and VP8
+\b A ROS Node to Stream Image Topics Via multiple formats including MJPEG, H.264 and VP8
 web_video_server converts ROS image streams into an MJPEG or other encoding and streams them via a socket connection.
 */

--- a/src/h264_streamer.cpp
+++ b/src/h264_streamer.cpp
@@ -1,0 +1,45 @@
+#include "web_video_server/h264_streamer.h"
+
+namespace web_video_server
+{
+
+H264Streamer::H264Streamer(const async_web_server_cpp::HttpRequest& request,
+                         async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    LibavStreamer(request, connection, nh, "mp4", "libx264", "video/mp4")
+{
+  /* possible quality presets:
+   * ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow, placebo
+   * no latency improvements observed with ultrafast instead of medium
+   */
+  preset_ = request.get_query_param_value_or_default("preset", "medium");
+}
+
+H264Streamer::~H264Streamer()
+{
+}
+
+void H264Streamer::initializeEncoder()
+{
+  av_opt_set(codec_context_->priv_data, "preset", preset_.c_str(), 0);
+  av_opt_set(codec_context_->priv_data, "tune", "zerolatency", 0);
+
+  // container format options
+  if (!strcmp(format_context_->oformat->name, "mp4")) {
+    // set up mp4 for streaming (instead of seekable file output)
+    av_dict_set(&opt_, "movflags", "+frag_keyframe+empty_moov+faststart", 0);
+  }
+}
+
+H264StreamerType::H264StreamerType() :
+    LibavStreamerType("mp4", "libx264", "video/mp4")
+{
+}
+
+boost::shared_ptr<ImageStreamer> H264StreamerType::create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                                  async_web_server_cpp::HttpConnectionPtr connection,
+                                                                  ros::NodeHandle& nh)
+{
+  return boost::shared_ptr<ImageStreamer>(new H264Streamer(request, connection, nh));
+}
+
+}

--- a/src/jpeg_streamers.cpp
+++ b/src/jpeg_streamers.cpp
@@ -58,7 +58,7 @@ void JpegSnapshotStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
   cv::imencode(".jpeg", img, encoded_buffer, encode_params);
 
   char stamp[20];
-  sprintf(stamp, "%.06lf", time.toSec());
+  std::snprintf(stamp, sizeof(stamp), "%.06lf", time.toSec());
   async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok).header("Connection", "close").header(
       "Server", "web_video_server").header("Cache-Control",
                                            "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0").header(

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -94,7 +94,11 @@ LibavStreamer::~LibavStreamer()
 }
 
 // allocates and initializes an AVFrame
+#if (LIBAVUTIL_VERSION_MAJOR < 52)
+AVFrame* createVideoFrame(PixelFormat pix_fmt, int width, int height)
+#else
 AVFrame* createVideoFrame(AVPixelFormat pix_fmt, int width, int height)
+#endif
 {
   AVFrame *frame = av_frame_alloc();
   if (!frame)

--- a/src/multipart_stream.cpp
+++ b/src/multipart_stream.cpp
@@ -18,7 +18,7 @@ void MultipartStream::sendInitialHeader() {
 
 void MultipartStream::sendPartHeader(const ros::Time &time, const std::string& type, size_t payload_size) {
   char stamp[20];
-  sprintf(stamp, "%.06lf", time.toSec());
+  std::snprintf(stamp, sizeof(stamp), "%.06lf", time.toSec());
   boost::shared_ptr<std::vector<async_web_server_cpp::HttpHeader> > headers(
       new std::vector<async_web_server_cpp::HttpHeader>());
   headers->push_back(async_web_server_cpp::HttpHeader("Content-type", type));

--- a/src/vp9_streamer.cpp
+++ b/src/vp9_streamer.cpp
@@ -1,0 +1,38 @@
+#include "web_video_server/vp9_streamer.h"
+
+namespace web_video_server
+{
+
+Vp9Streamer::Vp9Streamer(const async_web_server_cpp::HttpRequest& request,
+                         async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    LibavStreamer(request, connection, nh, "webm", "libvpx-vp9", "video/webm")
+{
+}
+Vp9Streamer::~Vp9Streamer()
+{
+}
+
+void Vp9Streamer::initializeEncoder()
+{
+  // codec options set up to provide somehow reasonable performance in cost of poor quality
+  // should be updated as soon as VP9 encoding matures
+  av_opt_set_int(codec_context_->priv_data, "pass", 1, 0);
+  av_opt_set_int(codec_context_->priv_data, "speed", 8, 0);
+  av_opt_set_int(codec_context_->priv_data, "cpu-used", 8, 0);  // 8 is max
+  codec_context_->bit_rate = 0;                                 // variable bitrate
+  av_opt_set_int(codec_context_->priv_data, "crf", 59, 0);      // 0..63 (higher is lower quality)
+}
+
+Vp9StreamerType::Vp9StreamerType() :
+    LibavStreamerType("webm", "libvpx-vp9", "video/webm")
+{
+}
+
+boost::shared_ptr<ImageStreamer> Vp9StreamerType::create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                                  async_web_server_cpp::HttpConnectionPtr connection,
+                                                                  ros::NodeHandle& nh)
+{
+  return boost::shared_ptr<ImageStreamer>(new Vp9Streamer(request, connection, nh));
+}
+
+}

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -9,6 +9,8 @@
 #include "web_video_server/ros_compressed_streamer.h"
 #include "web_video_server/jpeg_streamers.h"
 #include "web_video_server/vp8_streamer.h"
+#include "web_video_server/h264_streamer.h"
+#include "web_video_server/vp9_streamer.h"
 #include "async_web_server_cpp/http_reply.hpp"
 
 namespace web_video_server
@@ -54,6 +56,8 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
   stream_types_["mjpeg"] = boost::shared_ptr<ImageStreamerType>(new MjpegStreamerType());
   stream_types_["ros_compressed"] = boost::shared_ptr<ImageStreamerType>(new RosCompressedStreamerType());
   stream_types_["vp8"] = boost::shared_ptr<ImageStreamerType>(new Vp8StreamerType());
+  stream_types_["h264"] = boost::shared_ptr<ImageStreamerType>(new H264StreamerType());
+  stream_types_["vp9"] = boost::shared_ptr<ImageStreamerType>(new Vp9StreamerType());
 
   handler_group_.addHandlerForPath("/", boost::bind(&WebVideoServer::handle_list_streams, this, _1, _2, _3, _4));
   handler_group_.addHandlerForPath("/stream", boost::bind(&WebVideoServer::handle_stream, this, _1, _2, _3, _4));


### PR DESCRIPTION
Running web_video_server in Ubuntu 16.04 did not work out of the box.
The main difference is that in 16.04 _FFmpeg 2.8.8_ replaces _libav_ in the official packet repository.

While the main effort of these edits is to simply get it back to work, I fixed and updated a whole bunch of things throughout the code, mainly focusing on FFmpeg deprecation warnings.

I also added H.264 streaming and an experimental VP9 streamer. (VP9 encoding is quite new and libvpx-vp9 still has performance issues.)

I moved codec settings like quality values into the respective codec class (mainly vp8_streamer.cpp), because different codecs work differently and have different options, which behave differently and thus should not be generalized or mixed up. (E.g. newer, better codecs should default to a smaller bitrate.)
Maybe it is even going to favor further additions of codecs because of the smaller interface.
I also try to change as few codec values from default as possible, to maintain functionality across multiple FFmpeg/codec/OS versions. Also, it seems a good idea to trust codec developers in terms of presets/defaults.

The two most critical changes are:
I added a proper IO callback function instead of libav's `dyn_buffer` to get webm working again. (See: http://stackoverflow.com/questions/40284055/c-ffmpeg-starting-new-cluster-error/)

I changed `codec_context_->codec_id = output_format_->video_codec;`
to
`codec_context_->codec_id = codec_->id;`
because you do not always use the default codec suggested by the output format.
(E.g. default for webm is now vp9 and you probably want to use vp8 instead, which would raise a codec id mismatch error.)