### PR TITLE
web_video_server: fix bool function not returning

### DIFF
--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -28,11 +28,14 @@ static bool ros_connection_logger(async_web_server_cpp::HttpServerRequestHandler
   try
   {
     forward(request, connection, begin, end);
+    return true;
   }
   catch (std::exception &e)
   {
     ROS_WARN_STREAM("Error Handling Request: " << e.what());
+    return false;
   }
+  return false;
 }
 
 WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh) :


### PR DESCRIPTION
This fix is required when compiling the package with `clang`. Otherwise a SIGILL (Illegal instruction) is triggered.