### PR TITLE
use SteadyTimer for cleaning up inactive streams

### DIFF
--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -51,7 +51,7 @@ private:
   void cleanup_inactive_streams();
 
   ros::NodeHandle nh_;
-  ros::Timer cleanup_timer_;
+  ros::SteadyTimer cleanup_timer_;
   int ros_threads_;
   int port_;
   std::string address_;

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -42,7 +42,7 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
     nh_(nh), handler_group_(
         async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found))
 {
-  cleanup_timer_ = nh.createTimer(ros::Duration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
+  cleanup_timer_ = nh.createSteadyTimer(ros::WallDuration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
 
   private_nh.param("port", port_, 8080);
   private_nh.param("verbose", __verbose, true);


### PR DESCRIPTION
so that cleanup works correctly even if system time changes