### PR TITLE
Fix vp8 in kinetic add vp9 and h264 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(${PROJECT_NAME}
   src/image_streamer.cpp
   src/libav_streamer.cpp
   src/vp8_streamer.cpp
+  src/h264_streamer.cpp
+  src/vp9_streamer.cpp
   src/multipart_stream.cpp
   src/ros_compressed_streamer.cpp
   src/jpeg_streamers.cpp)

--- a/include/web_video_server/h264_streamer.h
+++ b/include/web_video_server/h264_streamer.h
@@ -1,0 +1,35 @@
+#ifndef H264_STREAMERS_H_
+#define H264_STREAMERS_H_
+
+#include <image_transport/image_transport.h>
+#include "web_video_server/libav_streamer.h"
+#include "async_web_server_cpp/http_request.hpp"
+#include "async_web_server_cpp/http_connection.hpp"
+
+namespace web_video_server
+{
+
+class H264Streamer : public LibavStreamer
+{
+public:
+  H264Streamer(const async_web_server_cpp::HttpRequest& request, async_web_server_cpp::HttpConnectionPtr connection,
+              ros::NodeHandle& nh);
+  ~H264Streamer();
+protected:
+  virtual void initializeEncoder();
+  std::string preset_;
+};
+
+class H264StreamerType : public LibavStreamerType
+{
+public:
+  H264StreamerType();
+  virtual boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                           async_web_server_cpp::HttpConnectionPtr connection,
+                                                           ros::NodeHandle& nh);
+};
+
+}
+
+#endif
+

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -40,6 +40,8 @@ protected:
   AVCodecContext* codec_context_;
   AVStream* video_stream_;
 
+  AVDictionary* opt_;   // container format options
+
 private:
   AVFrame* frame_;
   struct SwsContext* sws_context_;

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -53,6 +53,8 @@ private:
   int qmin_;
   int qmax_;
   int gop_;
+
+  uint8_t* io_buffer_;  // custom IO buffer
 };
 
 class LibavStreamerType : public ImageStreamerType

--- a/include/web_video_server/vp9_streamer.h
+++ b/include/web_video_server/vp9_streamer.h
@@ -1,0 +1,33 @@
+#ifndef VP9_STREAMERS_H_
+#define VP9_STREAMERS_H_
+
+#include <image_transport/image_transport.h>
+#include "web_video_server/libav_streamer.h"
+#include "async_web_server_cpp/http_request.hpp"
+#include "async_web_server_cpp/http_connection.hpp"
+
+namespace web_video_server
+{
+
+class Vp9Streamer : public LibavStreamer
+{
+public:
+  Vp9Streamer(const async_web_server_cpp::HttpRequest& request, async_web_server_cpp::HttpConnectionPtr connection,
+              ros::NodeHandle& nh);
+  ~Vp9Streamer();
+protected:
+  virtual void initializeEncoder();
+};
+
+class Vp9StreamerType : public LibavStreamerType
+{
+public:
+  Vp9StreamerType();
+  virtual boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                           async_web_server_cpp::HttpConnectionPtr connection,
+                                                           ros::NodeHandle& nh);
+};
+
+}
+
+#endif

--- a/src/h264_streamer.cpp
+++ b/src/h264_streamer.cpp
@@ -1,0 +1,49 @@
+#include "web_video_server/h264_streamer.h"
+
+namespace web_video_server
+{
+
+H264Streamer::H264Streamer(const async_web_server_cpp::HttpRequest& request,
+                         async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    LibavStreamer(request, connection, nh, "mp4", "libx264", "video/mp4")
+{
+  /* possible quality presets:
+   * ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow, placebo
+   * no latency improvements observed with ultrafast instead of medium
+   */
+  preset_ = request.get_query_param_value_or_default("preset", "ultrafast");
+}
+
+H264Streamer::~H264Streamer()
+{
+}
+
+void H264Streamer::initializeEncoder()
+{
+  av_opt_set(codec_context_->priv_data, "preset", preset_.c_str(), 0);
+  av_opt_set(codec_context_->priv_data, "tune", "zerolatency", 0);
+  av_opt_set_int(codec_context_->priv_data, "crf", 20, 0);
+  av_opt_set_int(codec_context_->priv_data, "bufsize", 100, 0);
+  av_opt_set_int(codec_context_->priv_data, "keyint", 30, 0);
+  av_opt_set_int(codec_context_->priv_data, "g", 1, 0);
+
+  // container format options
+  if (!strcmp(format_context_->oformat->name, "mp4")) {
+    // set up mp4 for streaming (instead of seekable file output)
+    av_dict_set(&opt_, "movflags", "+frag_keyframe+empty_moov+faststart", 0);
+  }
+}
+
+H264StreamerType::H264StreamerType() :
+    LibavStreamerType("mp4", "libx264", "video/mp4")
+{
+}
+
+boost::shared_ptr<ImageStreamer> H264StreamerType::create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                                  async_web_server_cpp::HttpConnectionPtr connection,
+                                                                  ros::NodeHandle& nh)
+{
+  return boost::shared_ptr<ImageStreamer>(new H264Streamer(request, connection, nh));
+}
+
+}

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -50,7 +50,7 @@ LibavStreamer::LibavStreamer(const async_web_server_cpp::HttpRequest &request,
                              const std::string &content_type) :
     ImageTransportImageStreamer(request, connection, nh), output_format_(0), format_context_(0), codec_(0), codec_context_(0), video_stream_(
         0), frame_(0), sws_context_(0), first_image_timestamp_(0), format_name_(
-        format_name), codec_name_(codec_name), content_type_(content_type)
+        format_name), codec_name_(codec_name), content_type_(content_type), opt_(0), io_buffer_(0)
 {
 
   bitrate_ = request.get_query_param_value_or_default<int>("bitrate", 100000);
@@ -222,7 +222,7 @@ void LibavStreamer::initialize(const cv::Mat &img)
       "Content-type", content_type_).header("Access-Control-Allow-Origin", "*").write(connection_);
 
   // Send video stream header
-  if (avformat_write_header(format_context_, NULL) < 0)
+  if (avformat_write_header(format_context_, &opt_) < 0)
   {
     async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::internal_server_error)(request_,
                                                                                                          connection_,

--- a/src/vp9_streamer.cpp
+++ b/src/vp9_streamer.cpp
@@ -1,0 +1,38 @@
+#include "web_video_server/vp9_streamer.h"
+
+namespace web_video_server
+{
+
+Vp9Streamer::Vp9Streamer(const async_web_server_cpp::HttpRequest& request,
+                         async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+    LibavStreamer(request, connection, nh, "webm", "libvpx-vp9", "video/webm")
+{
+}
+Vp9Streamer::~Vp9Streamer()
+{
+}
+
+void Vp9Streamer::initializeEncoder()
+{
+
+  // codec options set up to provide somehow reasonable performance in cost of poor quality
+  // should be updated as soon as VP9 encoding matures
+  av_opt_set_int(codec_context_->priv_data, "pass", 1, 0);
+  av_opt_set_int(codec_context_->priv_data, "speed", 8, 0);
+  av_opt_set_int(codec_context_->priv_data, "cpu-used", 4, 0);  // 8 is max
+  av_opt_set_int(codec_context_->priv_data, "crf", 20, 0);      // 0..63 (higher is lower quality)
+}
+
+Vp9StreamerType::Vp9StreamerType() :
+    LibavStreamerType("webm", "libvpx-vp9", "video/webm")
+{
+}
+
+boost::shared_ptr<ImageStreamer> Vp9StreamerType::create_streamer(const async_web_server_cpp::HttpRequest& request,
+                                                                  async_web_server_cpp::HttpConnectionPtr connection,
+                                                                  ros::NodeHandle& nh)
+{
+  return boost::shared_ptr<ImageStreamer>(new Vp9Streamer(request, connection, nh));
+}
+
+}

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -9,6 +9,8 @@
 #include "web_video_server/ros_compressed_streamer.h"
 #include "web_video_server/jpeg_streamers.h"
 #include "web_video_server/vp8_streamer.h"
+#include "web_video_server/h264_streamer.h"
+#include "web_video_server/vp9_streamer.h"
 #include "async_web_server_cpp/http_reply.hpp"
 
 namespace web_video_server
@@ -57,6 +59,8 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
   stream_types_["mjpeg"] = boost::shared_ptr<ImageStreamerType>(new MjpegStreamerType());
   stream_types_["ros_compressed"] = boost::shared_ptr<ImageStreamerType>(new RosCompressedStreamerType());
   stream_types_["vp8"] = boost::shared_ptr<ImageStreamerType>(new Vp8StreamerType());
+  stream_types_["h264"] = boost::shared_ptr<ImageStreamerType>(new H264StreamerType());
+  stream_types_["vp9"] = boost::shared_ptr<ImageStreamerType>(new Vp9StreamerType());
 
   handler_group_.addHandlerForPath("/", boost::bind(&WebVideoServer::handle_list_streams, this, _1, _2, _3, _4));
   handler_group_.addHandlerForPath("/stream", boost::bind(&WebVideoServer::handle_stream, this, _1, _2, _3, _4));


### PR DESCRIPTION
vp8 was tested both on Ubuntu 14.04 and Ubuntu 16.04. It works fine.
vp9 and h264 were tested on Ubuntu 16.04. They can work but the latency was about 10 seconds.
Most of the code were token from pull request #31 