### PR TITLE
use SteadyTimer (if available) for cleaning up inactive streams

### DIFF
--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -51,7 +51,11 @@ private:
   void cleanup_inactive_streams();
 
   ros::NodeHandle nh_;
+#if ROS_VERSION_MINIMUM(1, 13, 1)
+  ros::SteadyTimer cleanup_timer_;
+#else
   ros::Timer cleanup_timer_;
+#endif
   int ros_threads_;
   int port_;
   std::string address_;

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -44,7 +44,11 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
     nh_(nh), handler_group_(
         async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found))
 {
+#if ROS_VERSION_MINIMUM(1, 13, 1)
+  cleanup_timer_ = nh.createSteadyTimer(ros::WallDuration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
+#else
   cleanup_timer_ = nh.createTimer(ros::Duration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
+#endif
 
   private_nh.param("port", port_, 8080);
   private_nh.param("verbose", __verbose, true);


### PR DESCRIPTION
so that cleanup works correctly even if system time changes

SteadyTimer is available since roscpp 1.13.1

This is a follow up of #45 and should make it possible to use this without a branch for indigo (see #51)