### PR TITLE
Avoid queuing of images on slow ethernet connection

### DIFF
--- a/include/web_video_server/multipart_stream.h
+++ b/include/web_video_server/multipart_stream.h
@@ -4,12 +4,16 @@
 #include <ros/ros.h>
 #include <async_web_server_cpp/http_connection.hpp>
 
+#include <queue>
+
 namespace web_video_server
 {
 
 class MultipartStream {
 public:
-  MultipartStream(async_web_server_cpp::HttpConnectionPtr& connection, const std::string& boundry="boundarydonotcross");
+  MultipartStream(async_web_server_cpp::HttpConnectionPtr& connection,
+                  const std::string& boundry="boundarydonotcross",
+                  std::size_t max_queue_size=1);
 
   void sendInitialHeader();
   void sendPartHeader(const ros::Time &time, const std::string& type, size_t payload_size);
@@ -19,8 +23,13 @@ public:
 		async_web_server_cpp::HttpConnection::ResourcePtr resource);
 
 private:
+  bool isBusy();
+
+private:
+  const std::size_t max_queue_size_;
   async_web_server_cpp::HttpConnectionPtr connection_;
   std::string boundry_;
+  std::queue<boost::weak_ptr<const void> > pending_footers_;
 };
 
 }


### PR DESCRIPTION
If ethernet connection is slow, images are queued unlimitedly. To avoid this, keep track of image footers by storing a weak pointer. If queue is too long (>1 by default), drop new images.