### PR TITLE
fixed undeclared CODEC_FLAG_GLOBAL_HEADER

### DIFF
--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -1,6 +1,10 @@
 #include "web_video_server/libav_streamer.h"
 #include "async_web_server_cpp/http_reply.hpp"
 
+/*https://stackoverflow.com/questions/46884682/error-in-building-opencv-with-ffmpeg*/
+#define AV_CODEC_FLAG_GLOBAL_HEADER (1 << 22)
+#define CODEC_FLAG_GLOBAL_HEADER AV_CODEC_FLAG_GLOBAL_HEADER
+
 namespace web_video_server
 {
 


### PR DESCRIPTION
This change should probably not go in this file, not sure it is even needed, but if someone else has this problem, at least they would be able to find this. 

Might be worth looking in to. 

Compiled on a Mac High Sierra, using python 3 virtualenv and ROS Melodic, so mostly latest and greatest.