### PR TITLE
Pkg format 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(web_video_server)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp roslib cv_bridge image_transport async_web_server_cpp)
+find_package(catkin REQUIRED COMPONENTS roscpp roslib cv_bridge image_transport async_web_server_cpp sensor_msgs)
 find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>web_video_server</name>
   <version>0.1.0</version>
   <description>HTTP Streaming of ROS Image Topics in Multiple Formats</description>
@@ -22,10 +22,10 @@
   <build_depend>async_web_server_cpp</build_depend>
   <build_depend>ffmpeg</build_depend>
 
-  <run_depend>roscpp</run_depend>
-  <run_depend>roslib</run_depend>
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>image_transport</run_depend>
-  <run_depend>async_web_server_cpp</run_depend>
-  <run_depend>ffmpeg</run_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>roslib</exec_depend>
+  <exec_depend>cv_bridge</exec_depend>
+  <exec_depend>image_transport</exec_depend>
+  <exec_depend>async_web_server_cpp</exec_depend>
+  <exec_depend>ffmpeg</exec_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <build_depend>image_transport</build_depend>
   <build_depend>async_web_server_cpp</build_depend>
   <build_depend>ffmpeg</build_depend>
+  <build_depend>sensor_msgs</build_depend>
 
   <exec_depend>roscpp</exec_depend>
   <exec_depend>roslib</exec_depend>
@@ -28,4 +29,5 @@
   <exec_depend>image_transport</exec_depend>
   <exec_depend>async_web_server_cpp</exec_depend>
   <exec_depend>ffmpeg</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
 </package>


### PR DESCRIPTION
The first commit updates the package manifest to format 2 (similar to RobotWebTools/rosbridge_suite#348).

The second commit declares the dependency on `sensor_msgs` which is used in the code but not referenced in the manifest / CMake.