### PR TITLE
fix SteadyTimer check for backported ROS versions

### DIFF
--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -9,6 +9,8 @@
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"
 
+#define ROS_HAS_STEADYTIMER (ROS_VERSION_MINIMUM(1, 13, 1) || ((ROS_VERSION_MINOR == 12) && (ROS_VERSION_PATCH >= 8)))
+
 namespace web_video_server
 {
 
@@ -51,7 +53,7 @@ private:
   void cleanup_inactive_streams();
 
   ros::NodeHandle nh_;
-#if ROS_VERSION_MINIMUM(1, 13, 1) || defined USE_STEADY_TIMER
+#if ROS_HAS_STEADYTIMER || defined USE_STEADY_TIMER
   ros::SteadyTimer cleanup_timer_;
 #else
   ros::Timer cleanup_timer_;

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -44,7 +44,7 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
     nh_(nh), handler_group_(
         async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found))
 {
-#if ROS_VERSION_MINIMUM(1, 13, 1) || defined USE_STEADY_TIMER
+#if ROS_HAS_STEADYTIMER || defined USE_STEADY_TIMER
   cleanup_timer_ = nh.createSteadyTimer(ros::WallDuration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));
 #else
   cleanup_timer_ = nh.createTimer(ros::Duration(0.5), boost::bind(&WebVideoServer::cleanup_inactive_streams, this));


### PR DESCRIPTION
SteadyTimer is also available on kinetic now, see https://github.com/ros/ros_comm/blob/kinetic-devel/clients/roscpp/CHANGELOG.rst

So also check for these backports...