### PR TITLE
Add PngStreamer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,9 @@ add_executable(${PROJECT_NAME}
   src/vp9_streamer.cpp
   src/multipart_stream.cpp
   src/ros_compressed_streamer.cpp
-  src/jpeg_streamers.cpp)
+  src/jpeg_streamers.cpp
+  src/png_streamers.cpp
+)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}

--- a/include/web_video_server/png_streamers.h
+++ b/include/web_video_server/png_streamers.h
@@ -1,0 +1,51 @@
+#ifndef PNG_STREAMERS_H_
+#define PNG_STREAMERS_H_
+
+#include <image_transport/image_transport.h>
+#include "web_video_server/image_streamer.h"
+#include "async_web_server_cpp/http_request.hpp"
+#include "async_web_server_cpp/http_connection.hpp"
+#include "web_video_server/multipart_stream.h"
+
+namespace web_video_server
+{
+
+class PngStreamer : public ImageTransportImageStreamer
+{
+public:
+  PngStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
+              ros::NodeHandle& nh);
+
+protected:
+  virtual void sendImage(const cv::Mat &, const ros::Time &time);
+
+private:
+  MultipartStream stream_;
+  int quality_;
+};
+
+class PngStreamerType : public ImageStreamerType
+{
+public:
+  boost::shared_ptr<ImageStreamer> create_streamer(const async_web_server_cpp::HttpRequest &request,
+                                                   async_web_server_cpp::HttpConnectionPtr connection,
+                                                   ros::NodeHandle& nh);
+  std::string create_viewer(const async_web_server_cpp::HttpRequest &request);
+};
+
+class PngSnapshotStreamer : public ImageTransportImageStreamer
+{
+public:
+  PngSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
+                      async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh);
+
+protected:
+  virtual void sendImage(const cv::Mat &, const ros::Time &time);
+
+private:
+  int quality_;
+};
+
+}
+
+#endif

--- a/src/png_streamers.cpp
+++ b/src/png_streamers.cpp
@@ -1,0 +1,73 @@
+#include "web_video_server/png_streamers.h"
+#include "async_web_server_cpp/http_reply.hpp"
+
+namespace web_video_server
+{
+
+PngStreamer::PngStreamer(const async_web_server_cpp::HttpRequest &request,
+                         async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
+  ImageTransportImageStreamer(request, connection, nh), stream_(connection)
+{
+  quality_ = request.get_query_param_value_or_default<int>("quality", 3);
+  stream_.sendInitialHeader();
+}
+
+void PngStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
+{
+  std::vector<int> encode_params;
+  encode_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+  encode_params.push_back(quality_);
+
+  std::vector<uchar> encoded_buffer;
+  cv::imencode(".png", img, encoded_buffer, encode_params);
+
+  stream_.sendPartAndClear(time, "image/png", encoded_buffer);
+}
+
+boost::shared_ptr<ImageStreamer> PngStreamerType::create_streamer(const async_web_server_cpp::HttpRequest &request,
+                                                                  async_web_server_cpp::HttpConnectionPtr connection,
+                                                                  ros::NodeHandle& nh)
+{
+  return boost::shared_ptr<ImageStreamer>(new PngStreamer(request, connection, nh));
+}
+
+std::string PngStreamerType::create_viewer(const async_web_server_cpp::HttpRequest &request)
+{
+  std::stringstream ss;
+  ss << "<img src=\"/stream?";
+  ss << request.query;
+  ss << "\"></img>";
+  return ss.str();
+}
+
+PngSnapshotStreamer::PngSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
+                                         async_web_server_cpp::HttpConnectionPtr connection,
+                                         ros::NodeHandle& nh) :
+    ImageTransportImageStreamer(request, connection, nh)
+{
+  quality_ = request.get_query_param_value_or_default<int>("quality", 3);
+}
+
+void PngSnapshotStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
+{
+  std::vector<int> encode_params;
+  encode_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+  encode_params.push_back(quality_);
+
+  std::vector<uchar> encoded_buffer;
+  cv::imencode(".png", img, encoded_buffer, encode_params);
+
+  char stamp[20];
+  sprintf(stamp, "%.06lf", time.toSec());
+  async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok).header("Connection", "close").header(
+      "Server", "web_video_server").header("Cache-Control",
+                                           "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0").header(
+      "X-Timestamp", stamp).header("Pragma", "no-cache").header("Content-type", "image/png").header(
+      "Access-Control-Allow-Origin", "*").header("Content-Length",
+                                                 boost::lexical_cast<std::string>(encoded_buffer.size())).write(
+      connection_);
+  connection_->write_and_clear(encoded_buffer);
+  inactive_ = true;
+}
+
+}

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -8,6 +8,7 @@
 #include "web_video_server/web_video_server.h"
 #include "web_video_server/ros_compressed_streamer.h"
 #include "web_video_server/jpeg_streamers.h"
+#include "web_video_server/png_streamers.h"
 #include "web_video_server/vp8_streamer.h"
 #include "web_video_server/h264_streamer.h"
 #include "web_video_server/vp9_streamer.h"
@@ -61,6 +62,7 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
   private_nh.param("ros_threads", ros_threads_, 2);
 
   stream_types_["mjpeg"] = boost::shared_ptr<ImageStreamerType>(new MjpegStreamerType());
+  stream_types_["png"] = boost::shared_ptr<ImageStreamerType>(new PngStreamerType());
   stream_types_["ros_compressed"] = boost::shared_ptr<ImageStreamerType>(new RosCompressedStreamerType());
   stream_types_["vp8"] = boost::shared_ptr<ImageStreamerType>(new Vp8StreamerType());
   stream_types_["h264"] = boost::shared_ptr<ImageStreamerType>(new H264StreamerType());


### PR DESCRIPTION
Adds PNG streaming support which offers [optional] lossless compression. We can still compress the size of the PNG frame by tweaking the quality levels (from 0 - 9). The default quality is 3 (same as in OpenCV).