### PR TITLE
fix type format match bug in ros2

### DIFF
--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -211,11 +211,11 @@ bool WebVideoServer::handle_list_streams(const async_web_server_cpp::HttpRequest
     auto & topic_type = topic_and_types.second[0];  // explicitly take the first
     // TODO debugging
     fprintf(stderr, "topic_type: %s\n", topic_type.c_str());
-    if (topic_type == "sensor_msgs::msg::Image")
+    if (topic_type == "sensor_msgs/Image")
     {
       image_topics.push_back(topic_name);
     }
-    else if (topic_type == "sensor_msgs::msg::CameraInfo")
+    else if (topic_type == "sensor_msgs/CameraInfo")
     {
       camera_info_topics.push_back(topic_name);
     }


### PR DESCRIPTION
in ros2 the rclcpp::Node::get_topic_names_and_types() returns the topic name and types, and the types is split by slash(/) not double colon(::). something like:

|name |type |
| ------ | ------ |
| /clock | rosgraph_msgs/Clock |
| /parameter_events | rcl_interfaces/ParameterEvent |

the code check the type using ::.