### PR TITLE
using shared_ptr to manage the cleanup_timer

### DIFF
--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -35,6 +35,8 @@ public:
    */
   void spin();
 
+  void setup_cleanup_inactive_streams();
+
   bool handle_stream(const async_web_server_cpp::HttpRequest &request,
                      async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
@@ -51,7 +53,7 @@ private:
   void cleanup_inactive_streams();
 
   rclcpp::Node::SharedPtr nh_;
-  rclcpp::WallTimer<rclcpp::VoidCallbackType> cleanup_timer_;
+  rclcpp::WallTimer<rclcpp::VoidCallbackType>::SharedPtr cleanup_timer_;
   int ros_threads_;
   int port_;
   std::string address_;


### PR DESCRIPTION
when the stream is inactive, the related resource will be released, here they use the timer to detect the failure ones, but the timer is not bind for the node, I correct it using another function `setup_cleanup_inactive_streams`, for the origin's implementation bind is in the constructor, it's not safe to use `this` in constructor, expecially before the constructor is actually called, so I put it in another function.