### PR TITLE
Restream buffered frames with minimum publish rate

### DIFF
--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -18,12 +18,18 @@ public:
 		ros::NodeHandle& nh);
 
   virtual void start() = 0;
+  virtual ~ImageStreamer();
 
   bool isInactive()
   {
     return inactive_;
   }
   ;
+
+  /**
+   * Restreams the last received image frame if older than max_age.
+   */
+  virtual void restreamFrame(double max_age) = 0;
 
   std::string getTopic()
   {
@@ -45,12 +51,12 @@ class ImageTransportImageStreamer : public ImageStreamer
 public:
   ImageTransportImageStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
 			      ros::NodeHandle& nh);
-
+  virtual ~ImageTransportImageStreamer();
   virtual void start();
 
 protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time) = 0;
-
+  virtual void restreamFrame(double max_age);
   virtual void initialize(const cv::Mat &);
 
   image_transport::Subscriber image_sub_;
@@ -58,6 +64,11 @@ protected:
   int output_height_;
   bool invert_;
   std::string default_transport_;
+
+  ros::Time last_frame;
+  cv::Mat output_size_image;
+  boost::mutex send_mutex_;
+
 private:
   image_transport::ImageTransport it_;
   bool initialized_;

--- a/include/web_video_server/jpeg_streamers.h
+++ b/include/web_video_server/jpeg_streamers.h
@@ -15,7 +15,7 @@ class MjpegStreamer : public ImageTransportImageStreamer
 public:
   MjpegStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
                 ros::NodeHandle& nh);
-
+  ~MjpegStreamer();
 protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time);
 
@@ -38,7 +38,7 @@ class JpegSnapshotStreamer : public ImageTransportImageStreamer
 public:
   JpegSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
                        async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh);
-
+  ~JpegSnapshotStreamer();
 protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time);
 

--- a/include/web_video_server/png_streamers.h
+++ b/include/web_video_server/png_streamers.h
@@ -15,7 +15,7 @@ class PngStreamer : public ImageTransportImageStreamer
 public:
   PngStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
               ros::NodeHandle& nh);
-
+  ~PngStreamer();
 protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time);
 
@@ -38,7 +38,7 @@ class PngSnapshotStreamer : public ImageTransportImageStreamer
 public:
   PngSnapshotStreamer(const async_web_server_cpp::HttpRequest &request,
                       async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh);
-
+  ~PngSnapshotStreamer();
 protected:
   virtual void sendImage(const cv::Mat &, const ros::Time &time);
 

--- a/include/web_video_server/ros_compressed_streamer.h
+++ b/include/web_video_server/ros_compressed_streamer.h
@@ -15,13 +15,21 @@ class RosCompressedStreamer : public ImageStreamer
 public:
   RosCompressedStreamer(const async_web_server_cpp::HttpRequest &request, async_web_server_cpp::HttpConnectionPtr connection,
 			ros::NodeHandle& nh);
+  ~RosCompressedStreamer();
+
   virtual void start();
+  virtual void restreamFrame(double max_age);
+
+protected:
+  virtual void sendImage(const sensor_msgs::CompressedImageConstPtr &msg, const ros::Time &time);
 
 private:
   void imageCallback(const sensor_msgs::CompressedImageConstPtr &msg);
-  virtual void restreamFrame(double max_age);
   MultipartStream stream_;
   ros::Subscriber image_sub_;
+  ros::Time last_frame;
+  sensor_msgs::CompressedImageConstPtr last_msg;
+  boost::mutex send_mutex_;
 };
 
 class RosCompressedStreamerType : public ImageStreamerType

--- a/include/web_video_server/ros_compressed_streamer.h
+++ b/include/web_video_server/ros_compressed_streamer.h
@@ -19,7 +19,7 @@ public:
 
 private:
   void imageCallback(const sensor_msgs::CompressedImageConstPtr &msg);
-
+  virtual void restreamFrame(double max_age);
   MultipartStream stream_;
   ros::Subscriber image_sub_;
 };

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -50,6 +50,7 @@ public:
                            async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
 private:
+  void restreamFrames(double max_age);
   void cleanup_inactive_streams();
 
   ros::NodeHandle nh_;
@@ -59,6 +60,7 @@ private:
   ros::Timer cleanup_timer_;
 #endif
   int ros_threads_;
+  double publish_rate_;
   int port_;
   std::string address_;
   boost::shared_ptr<async_web_server_cpp::HttpServer> server_;

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -1,5 +1,6 @@
 #include "web_video_server/image_streamer.h"
 #include <cv_bridge/cv_bridge.h>
+#include <iostream>
 
 namespace web_video_server
 {
@@ -11,6 +12,10 @@ ImageStreamer::ImageStreamer(const async_web_server_cpp::HttpRequest &request,
   topic_ = request.get_query_param_value_or_default("topic", "");
 }
 
+ImageStreamer::~ImageStreamer()
+{
+}
+
 ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_cpp::HttpRequest &request,
                              async_web_server_cpp::HttpConnectionPtr connection, ros::NodeHandle& nh) :
   ImageStreamer(request, connection, nh), it_(nh), initialized_(false)
@@ -19,6 +24,10 @@ ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_
   output_height_ = request.get_query_param_value_or_default<int>("height", -1);
   invert_ = request.has_query_param("invert");
   default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
+}
+
+ImageTransportImageStreamer::~ImageTransportImageStreamer()
+{
 }
 
 void ImageTransportImageStreamer::start()
@@ -39,6 +48,37 @@ void ImageTransportImageStreamer::start()
 
 void ImageTransportImageStreamer::initialize(const cv::Mat &)
 {
+}
+
+void ImageTransportImageStreamer::restreamFrame(double max_age)
+{
+  if (inactive_ || !initialized_ )
+    return;
+  try {
+    if ( last_frame + ros::Duration(max_age) < ros::Time::now() ) {
+      boost::mutex::scoped_lock lock(send_mutex_);
+      sendImage(output_size_image, ros::Time::now() ); // don't update last_frame, it may remain an old value.
+    }
+  }
+  catch (boost::system::system_error &e)
+  {
+    // happens when client disconnects
+    ROS_DEBUG("system_error exception: %s", e.what());
+    inactive_ = true;
+    return;
+  }
+  catch (std::exception &e)
+  {
+    ROS_ERROR_THROTTLE(30, "exception: %s", e.what());
+    inactive_ = true;
+    return;
+  }
+  catch (...)
+  {
+    ROS_ERROR_THROTTLE(30, "exception");
+    inactive_ = true;
+    return;
+  }
 }
 
 void ImageTransportImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr &msg)
@@ -84,7 +124,7 @@ void ImageTransportImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr
       cv::flip(img, img, true);
     }
 
-    cv::Mat output_size_image;
+    boost::mutex::scoped_lock lock(send_mutex_); // protects output_size_image
     if (output_width_ != input_width || output_height_ != input_height)
     {
       cv::Mat img_resized;
@@ -102,7 +142,9 @@ void ImageTransportImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr
       initialize(output_size_image);
       initialized_ = true;
     }
-    sendImage(output_size_image, msg->header.stamp);
+
+    last_frame = ros::Time::now();
+    sendImage(output_size_image, last_frame );
 
   }
   catch (cv_bridge::Exception &e)

--- a/src/png_streamers.cpp
+++ b/src/png_streamers.cpp
@@ -12,6 +12,12 @@ PngStreamer::PngStreamer(const async_web_server_cpp::HttpRequest &request,
   stream_.sendInitialHeader();
 }
 
+PngStreamer::~PngStreamer()
+{
+  this->inactive_ = true;
+  boost::mutex::scoped_lock lock(send_mutex_); // protects sendImage.
+}
+
 void PngStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
 {
   std::vector<int> encode_params;
@@ -48,6 +54,12 @@ PngSnapshotStreamer::PngSnapshotStreamer(const async_web_server_cpp::HttpRequest
   quality_ = request.get_query_param_value_or_default<int>("quality", 3);
 }
 
+PngSnapshotStreamer::~PngSnapshotStreamer()
+{
+  this->inactive_ = true;
+  boost::mutex::scoped_lock lock(send_mutex_); // protects sendImage.
+}
+
 void PngSnapshotStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
 {
   std::vector<int> encode_params;
@@ -59,13 +71,19 @@ void PngSnapshotStreamer::sendImage(const cv::Mat &img, const ros::Time &time)
 
   char stamp[20];
   sprintf(stamp, "%.06lf", time.toSec());
-  async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok).header("Connection", "close").header(
-      "Server", "web_video_server").header("Cache-Control",
-                                           "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0").header(
-      "X-Timestamp", stamp).header("Pragma", "no-cache").header("Content-type", "image/png").header(
-      "Access-Control-Allow-Origin", "*").header("Content-Length",
-                                                 boost::lexical_cast<std::string>(encoded_buffer.size())).write(
-      connection_);
+  async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok)
+      .header("Connection", "close")
+      .header("Server", "web_video_server")
+      .header("Cache-Control",
+              "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, "
+              "max-age=0")
+      .header("X-Timestamp", stamp)
+      .header("Pragma", "no-cache")
+      .header("Content-type", "image/png")
+      .header("Access-Control-Allow-Origin", "*")
+      .header("Content-Length",
+              boost::lexical_cast<std::string>(encoded_buffer.size()))
+      .write(connection_);
   connection_->write_and_clear(encoded_buffer);
   inactive_ = true;
 }

--- a/src/ros_compressed_streamer.cpp
+++ b/src/ros_compressed_streamer.cpp
@@ -10,6 +10,10 @@ RosCompressedStreamer::RosCompressedStreamer(const async_web_server_cpp::HttpReq
   stream_.sendInitialHeader();
 }
 
+void RosCompressedStreamer::restreamFrame(double max_age)
+{
+}
+
 void RosCompressedStreamer::start() {
   std::string compressed_topic = topic_ + "/compressed";
   image_sub_ = nh_.subscribe(compressed_topic, 1, &RosCompressedStreamer::imageCallback, this);


### PR DESCRIPTION
Image topics that are occasionally publishing end up buffered internally if not re-streamed at some rate. This PR adds an optional `publish_rate` parameter which if provided will make the server continuously restream messages older than the publish rate.

PS. We have been using this for many years at Pickit, albeit on an [old diverged fork](https://github.com/Intermodalics/web_video_server/tree/develop-minimum-rate-stream). This adapts some work @psoetens did four years ago, on top of the latest mainline version.

083332e444b495b7a5cae2079e26819046dc270a
2fb83e0d096f768e9d978c80d59ded62bcf45e37
71802876bf7a8170e92737eacf33a9b25724c91c
6ce0eed837b302efbf1d35ce41e8a6fa025cd0a4