### PR TITLE
Fix build for ROS2 Foxy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,6 @@ target_link_libraries(${PROJECT_NAME}
   ${swscale_LIBRARIES}
 )
 
-ament_package()
-
 #############
 ## Install ##
 #############
@@ -81,3 +79,5 @@ install(DIRECTORY include/${PROJECT_NAME}/
    DESTINATION include/${PROJECT_NAME}
    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )
+
+ament_package()

--- a/include/web_video_server/h264_streamer.h
+++ b/include/web_video_server/h264_streamer.h
@@ -1,7 +1,7 @@
 #ifndef H264_STREAMERS_H_
 #define H264_STREAMERS_H_
 
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include "web_video_server/libav_streamer.h"
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -2,8 +2,8 @@
 #define IMAGE_STREAMER_H_
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
-#include <image_transport/transport_hints.h>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/transport_hints.hpp>
 #include <opencv2/opencv.hpp>
 #include "async_web_server_cpp/http_server.hpp"
 #include "async_web_server_cpp/http_request.hpp"

--- a/include/web_video_server/jpeg_streamers.h
+++ b/include/web_video_server/jpeg_streamers.h
@@ -1,7 +1,7 @@
 #ifndef JPEG_STREAMERS_H_
 #define JPEG_STREAMERS_H_
 
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include "web_video_server/image_streamer.h"
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -1,7 +1,7 @@
 #ifndef LIBAV_STREAMERS_H_
 #define LIBAV_STREAMERS_H_
 
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include "web_video_server/image_streamer.h"
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"

--- a/include/web_video_server/png_streamers.h
+++ b/include/web_video_server/png_streamers.h
@@ -1,7 +1,7 @@
 #ifndef PNG_STREAMERS_H_
 #define PNG_STREAMERS_H_
 
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include "web_video_server/image_streamer.h"
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"

--- a/include/web_video_server/vp8_streamer.h
+++ b/include/web_video_server/vp8_streamer.h
@@ -37,7 +37,7 @@
 #ifndef VP8_STREAMERS_H_
 #define VP8_STREAMERS_H_
 
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include "web_video_server/libav_streamer.h"
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"

--- a/include/web_video_server/vp9_streamer.h
+++ b/include/web_video_server/vp9_streamer.h
@@ -1,7 +1,7 @@
 #ifndef VP9_STREAMERS_H_
 #define VP9_STREAMERS_H_
 
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include "web_video_server/libav_streamer.h"
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"

--- a/package.xml
+++ b/package.xml
@@ -28,4 +28,8 @@
   <exec_depend>async_web_server_cpp</exec_depend>
   <exec_depend>ffmpeg</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/src/jpeg_streamers.cpp
+++ b/src/jpeg_streamers.cpp
@@ -21,7 +21,7 @@ MjpegStreamer::~MjpegStreamer()
 void MjpegStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
 {
   std::vector<int> encode_params;
-  encode_params.push_back(CV_IMWRITE_JPEG_QUALITY);
+  encode_params.push_back(cv::IMWRITE_JPEG_QUALITY);
   encode_params.push_back(quality_);
 
   std::vector<uchar> encoded_buffer;
@@ -63,7 +63,7 @@ JpegSnapshotStreamer::~JpegSnapshotStreamer()
 void JpegSnapshotStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
 {
   std::vector<int> encode_params;
-  encode_params.push_back(CV_IMWRITE_JPEG_QUALITY);
+  encode_params.push_back(cv::IMWRITE_JPEG_QUALITY);
   encode_params.push_back(quality_);
 
   std::vector<uchar> encoded_buffer;

--- a/src/png_streamers.cpp
+++ b/src/png_streamers.cpp
@@ -21,7 +21,7 @@ PngStreamer::~PngStreamer()
 void PngStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
 {
   std::vector<int> encode_params;
-  encode_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+  encode_params.push_back(cv::IMWRITE_PNG_COMPRESSION);
   encode_params.push_back(quality_);
 
   std::vector<uchar> encoded_buffer;
@@ -63,7 +63,7 @@ PngSnapshotStreamer::~PngSnapshotStreamer()
 void PngSnapshotStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
 {
   std::vector<int> encode_params;
-  encode_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+  encode_params.push_back(cv::IMWRITE_PNG_COMPRESSION);
   encode_params.push_back(quality_);
 
   std::vector<uchar> encoded_buffer;

--- a/src/ros_compressed_streamer.cpp
+++ b/src/ros_compressed_streamer.cpp
@@ -19,7 +19,7 @@ RosCompressedStreamer::~RosCompressedStreamer()
 void RosCompressedStreamer::start() {
   std::string compressed_topic = topic_ + "/compressed";
   image_sub_ = nh_->create_subscription<sensor_msgs::msg::CompressedImage>(
-    compressed_topic, std::bind(&RosCompressedStreamer::imageCallback, this, std::placeholders::_1), 1);
+    compressed_topic, 1, std::bind(&RosCompressedStreamer::imageCallback, this, std::placeholders::_1));
 }
 
 void RosCompressedStreamer::restreamFrame(double max_age)

--- a/src/ros_compressed_streamer.cpp
+++ b/src/ros_compressed_streamer.cpp
@@ -77,7 +77,7 @@ void RosCompressedStreamer::sendImage(const sensor_msgs::msg::CompressedImage::C
 void RosCompressedStreamer::imageCallback(const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg) {
   boost::mutex::scoped_lock lock(send_mutex_); // protects last_msg and last_frame
   last_msg = msg;
-  last_frame = rclcpp::Time(msg->header.stamp.sec, msg->header.stamp.nanosec);
+  last_frame = rclcpp::Time(msg->header.stamp);
   sendImage(last_msg, last_frame);
 }
 

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -135,7 +135,7 @@ void WebVideoServer::spin()
 {
   server_->run();
   RCLCPP_INFO(nh_->get_logger(), "Waiting For connections on %s:%d", address_.c_str(), port_);
-  rclcpp::executors::MultiThreadedExecutor spinner(rclcpp::executor::create_default_executor_arguments(), ros_threads_);
+  rclcpp::executors::MultiThreadedExecutor spinner(rclcpp::ExecutorOptions(), ros_threads_);
   spinner.add_node(nh_);
   if ( publish_rate_ > 0 ) {
     nh_->create_wall_timer(1s / publish_rate_, [this](){restreamFrames(1.0 / publish_rate_);});
@@ -298,11 +298,11 @@ bool WebVideoServer::handle_list_streams(const async_web_server_cpp::HttpRequest
     auto & topic_type = topic_and_types.second[0];  // explicitly take the first
     // TODO debugging
     fprintf(stderr, "topic_type: %s\n", topic_type.c_str());
-    if (topic_type == "sensor_msgs/Image")
+    if (topic_type == "sensor_msgs/msg/Image")
     {
       image_topics.push_back(topic_name);
     }
-    else if (topic_type == "sensor_msgs/CameraInfo")
+    else if (topic_type == "sensor_msgs/msg/CameraInfo")
     {
       camera_info_topics.push_back(topic_name);
     }


### PR DESCRIPTION
Building on #107 with some additional changes that I needed to get the package to successfully build under Foxy. Not sure on the proper procedure here since the previous PR was never merged, so just opening a second PR for now.

### Notes

* Credit to @nplan for the subscription API and topic discovery fixes from #107.
* Switched `image_transport.h` to `image_transport.hpp` to fix a deprecation warning.
* Moved `ament_package()` to the end of `CMakeLists.txt`. I believe this solved the issue with not being able to `ros2 run` after `source dev_ws/install/setup.bash` as mentioned in https://github.com/RobotWebTools/web_video_server/issues/105#issuecomment-667663265
* The `CV_IMWRITE_JPEG_QUALITY` and `CV_IMWRITE_PNG_COMPRESSION` symbols from OpenCV were not found by the compiler. Switched to `cv::IMWRITE_JPEG_QUALITY` and `cv::IMWRITE_PNG_COMPRESSION` which should have the same values.
  * See https://docs.opencv.org/4.2.0/d6/d87/imgcodecs_8hpp.html and https://docs.opencv.org/3.4/da/d0a/group__imgcodecs__c.html
* Switched from `rclcpp::executor::create_default_executor_arguments()` to `rclcpp::ExecutorOptions()` to fix a deprecation warning.

One unresolved issue is that there are some deprecation warnings regarding libavcodec. I wasn't familiar enough with that library to attempt fixing them, so I just left them for now. Will post an example of the warnings in a comment below.

### Library Versions

```
ros-foxy-ros-core/now 0.9.2-1focal.20201008.004629 amd64
libopencv-core4.2/now 4.2.0+dfsg-5 amd64
libavcodec58/now 7:4.2.4-1ubuntu0.1 amd64
```