### PR TITLE
Fix passing parameters from the command line

### DIFF
--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -377,8 +377,12 @@ bool WebVideoServer::handle_list_streams(const async_web_server_cpp::HttpRequest
 int main(int argc, char **argv)
 {
   rclcpp::init(argc, argv);
+
+  rclcpp::NodeOptions options;
+  options.automatically_declare_parameters_from_overrides(true);
+
   auto nh = std::make_shared<rclcpp::Node>("web_video_server");
-  auto private_nh = std::make_shared<rclcpp::Node>("_web_video_server");
+  auto private_nh = std::make_shared<rclcpp::Node>("_web_video_server", options);
 
   web_video_server::WebVideoServer server(nh, private_nh);
   server.setup_cleanup_inactive_streams();


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
This fix enables passing parameters to the `web_video_server` node via the command line or a `yaml` file, e.g. to change the `port` or `address`.  
Currently this does not work since the parameters are not declared in the node.  
To fix the issue the node option `automatically_declare_parameters_from_overrides` was set to true.

This then enables passing parameters to the node in ROS 2 (Foxy) like so:

```
ros2 run web_video_server web_video_server --ros-args -p port:=8181
```

or like this:

```
ros2 run web_video_server web_video_server --ros-args --params-file /path/to/your/params.yaml
```

where `params.yaml`:

```
_web_video_server:
  ros__parameters:
    port: 8181
```

<!-- Link relevant GitHub issues -->
