### PR TITLE
Sync ros2 branch up to version 0.2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog for package web_video_server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.1.0 (2022-03-30)
+------------------
+* Sync ROS 2 package to 0.2.2
+
+0.2.2 (2021-07-23)
+------------------
+* fix vp9 and h264, support for opencv4 and ffmpeg 4 (`#103 <https://github.com/RobotWebTools/web_video_server/issues/103>`_)
+* add a mention of mjpegcanvasjs in the readme (`#100 <https://github.com/RobotWebTools/web_video_server/issues/100>`_)
+* fix multipart_stream.cpp HttpHeader values in order to solve DOMException(cross origin) CORS issue (`#92 <https://github.com/RobotWebTools/web_video_server/issues/92>`_)
+* Contributors: Gady, okapi1125, randoms
+
 1.0.0 (2019-09-20)
 ------------------
 * Port to ROS 2

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This node combines the capabilities of [ros_web_video](https://github.com/RobotW
 For full documentation, see [the ROS wiki](http://ros.org/wiki/web_video_server).
 
 [Doxygen](http://docs.ros.org/indigo/api/web_video_server/html/) files can be found on the ROS wiki.
+[mjpegcanvasjs](https://github.com/rctoris/mjpegcanvasjs) can be used to display a MJPEG stream from the ROS web_video_server
 
 This project is released as part of the [Robot Web Tools](http://robotwebtools.org/) effort.
 

--- a/include/web_video_server/jpeg_streamers.h
+++ b/include/web_video_server/jpeg_streamers.h
@@ -2,6 +2,7 @@
 #define JPEG_STREAMERS_H_
 
 #include <image_transport/image_transport.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include "web_video_server/image_streamer.h"
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"

--- a/include/web_video_server/png_streamers.h
+++ b/include/web_video_server/png_streamers.h
@@ -2,6 +2,7 @@
 #define PNG_STREAMERS_H_
 
 #include <image_transport/image_transport.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include "web_video_server/image_streamer.h"
 #include "async_web_server_cpp/http_request.hpp"
 #include "async_web_server_cpp/http_connection.hpp"

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>web_video_server</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>HTTP Streaming of ROS Image Topics in Multiple Formats</description>
 
   <maintainer email="rctoris@wpi.edu">Russell Toris</maintainer>

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -117,10 +117,8 @@ void ImageTransportImageStreamer::imageCallback(const sensor_msgs::msg::Image::C
     int input_width = img.cols;
     int input_height = img.rows;
 
-    if (output_width_ == -1)
-      output_width_ = input_width;
-    if (output_height_ == -1)
-      output_height_ = input_height;
+    output_width_ = input_width;
+    output_height_ = input_height;
 
     if (invert_)
     {
@@ -149,7 +147,7 @@ void ImageTransportImageStreamer::imageCallback(const sensor_msgs::msg::Image::C
     }
 
     last_frame = nh_->now();
-    sendImage(output_size_image, last_frame );
+    sendImage(output_size_image, msg->header.stamp);
 
   }
   catch (cv_bridge::Exception &e)

--- a/src/jpeg_streamers.cpp
+++ b/src/jpeg_streamers.cpp
@@ -21,7 +21,11 @@ MjpegStreamer::~MjpegStreamer()
 void MjpegStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
 {
   std::vector<int> encode_params;
+#if CV_VERSION_MAJOR >= 3
   encode_params.push_back(cv::IMWRITE_JPEG_QUALITY);
+#else
+  encode_params.push_back(CV_IMWRITE_JPEG_QUALITY);
+#endif
   encode_params.push_back(quality_);
 
   std::vector<uchar> encoded_buffer;
@@ -63,7 +67,11 @@ JpegSnapshotStreamer::~JpegSnapshotStreamer()
 void JpegSnapshotStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
 {
   std::vector<int> encode_params;
+#if CV_VERSION_MAJOR >= 3
   encode_params.push_back(cv::IMWRITE_JPEG_QUALITY);
+#else
+  encode_params.push_back(CV_IMWRITE_JPEG_QUALITY);
+#endif
   encode_params.push_back(quality_);
 
   std::vector<uchar> encoded_buffer;

--- a/src/multipart_stream.cpp
+++ b/src/multipart_stream.cpp
@@ -17,7 +17,8 @@ void MultipartStream::sendInitialHeader() {
       "Server", "web_video_server").header("Cache-Control",
                                            "no-cache, no-store, must-revalidate, pre-check=0, post-check=0, max-age=0").header(
       "Pragma", "no-cache").header("Content-type", "multipart/x-mixed-replace;boundary="+boundry_).header(
-      "Access-Control-Allow-Origin", "*").write(connection_);
+      "Access-Control-Allow-Origin", "*").header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,HEAD,OPTIONS").header(
+      "Access-Control-Allow-Headers", "Origin, Authorization, Accept, Content-Type").header("Access-Control-Max-Age", "3600").write(connection_);
   connection_->write("--"+boundry_+"\r\n");
 }
 
@@ -28,6 +29,10 @@ void MultipartStream::sendPartHeader(const rclcpp::Time &time, const std::string
       new std::vector<async_web_server_cpp::HttpHeader>());
   headers->push_back(async_web_server_cpp::HttpHeader("Content-type", type));
   headers->push_back(async_web_server_cpp::HttpHeader("X-Timestamp", stamp));
+  headers->push_back(async_web_server_cpp::HttpHeader("Access-Control-Allow-Origin", "*"));
+  headers->push_back(async_web_server_cpp::HttpHeader("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,HEAD,OPTIONS"));
+  headers->push_back(async_web_server_cpp::HttpHeader("Access-Control-Allow-Headers", "Origin, Authorization, Accept, Content-Type"));
+  headers->push_back(async_web_server_cpp::HttpHeader("Access-Control-Max-Age", "3600"));
   headers->push_back(
       async_web_server_cpp::HttpHeader("Content-Length", boost::lexical_cast<std::string>(payload_size)));
   connection_->write(async_web_server_cpp::HttpReply::to_buffers(*headers), headers);

--- a/src/png_streamers.cpp
+++ b/src/png_streamers.cpp
@@ -21,7 +21,11 @@ PngStreamer::~PngStreamer()
 void PngStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
 {
   std::vector<int> encode_params;
+#if CV_VERSION_MAJOR >= 3
   encode_params.push_back(cv::IMWRITE_PNG_COMPRESSION);
+#else
+  encode_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+#endif
   encode_params.push_back(quality_);
 
   std::vector<uchar> encoded_buffer;
@@ -63,7 +67,11 @@ PngSnapshotStreamer::~PngSnapshotStreamer()
 void PngSnapshotStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
 {
   std::vector<int> encode_params;
+#if CV_VERSION_MAJOR >= 3
   encode_params.push_back(cv::IMWRITE_PNG_COMPRESSION);
+#else
+  encode_params.push_back(CV_IMWRITE_PNG_COMPRESSION);
+#endif
   encode_params.push_back(quality_);
 
   std::vector<uchar> encoded_buffer;


### PR DESCRIPTION
### Public API Changes
<!-- Describe any changes to the public API, or write "None" -->
None

### Description
<!-- Describe what has changed, and motivation behind those changes -->
Ported the changes on `develop` between versions 0.2.1 and 0.2.2. This fixes the libav deprecation build warnings.

I'd also be interested in helping to get a Foxy package build published if someone can point me in the right direction to help out with that.

<!-- Link relevant GitHub issues -->
#### PRs that were ported
* fix multipart_stream.cpp HttpHeader values in order to solve DOMException(cross origin) CORS issue (#92)
* add a mention of mjpegcanvasjs in the readme (#100)
* fix vp9 and h264, support for opencv4 and ffmpeg 4 (#103)
