### PR TITLE
Add support for u16; colormaps

### DIFF
--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -74,6 +74,10 @@ private:
   bool initialized_;
 
   void imageCallback(const sensor_msgs::ImageConstPtr &msg);
+
+  
+  float min_v_ = NAN, max_v_ = NAN;
+  int colormap_ = -1;
 };
 
 class ImageStreamerType

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -65,7 +65,7 @@ protected:
   bool invert_;
   std::string default_transport_;
 
-  ros::Time last_frame;
+  ros::WallTime last_frame;
   cv::Mat output_size_image;
   boost::mutex send_mutex_;
 

--- a/include/web_video_server/multipart_stream.h
+++ b/include/web_video_server/multipart_stream.h
@@ -10,7 +10,7 @@ namespace web_video_server
 {
 
 struct PendingFooter {
-  ros::Time timestamp;
+  ros::WallTime timestamp;
   boost::weak_ptr<std::string> contents;
 };
 

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -49,6 +49,9 @@ public:
   bool handle_list_streams(const async_web_server_cpp::HttpRequest &request,
                            async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
 
+  bool handle_list_streams_json(const async_web_server_cpp::HttpRequest &request,
+                           async_web_server_cpp::HttpConnectionPtr connection, const char* begin, const char* end);
+
 private:
   void restreamFrames(double max_age);
   void cleanup_inactive_streams();

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -63,7 +63,7 @@ void ImageTransportImageStreamer::restreamFrame(double max_age)
   if (inactive_ || !initialized_ )
     return;
   try {
-    if ( last_frame + ros::Duration(max_age) < ros::Time::now() ) {
+    if ( last_frame + ros::WallDuration(max_age) < ros::WallTime::now() ) {
       boost::mutex::scoped_lock lock(send_mutex_);
       sendImage(output_size_image, ros::Time::now() ); // don't update last_frame, it may remain an old value.
     }
@@ -154,7 +154,7 @@ void ImageTransportImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr
       initialized_ = true;
     }
 
-    last_frame = ros::Time::now();
+    last_frame = ros::WallTime::now();
     sendImage(output_size_image, msg->header.stamp);
   }
   catch (cv_bridge::Exception &e)

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -24,6 +24,14 @@ ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_
   output_height_ = request.get_query_param_value_or_default<int>("height", -1);
   invert_ = request.has_query_param("invert");
   default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
+
+  min_v_ = request.get_query_param_value_or_default<float>("min", min_v_);
+  max_v_ = request.get_query_param_value_or_default<float>("max", max_v_);
+  colormap_ = request.get_query_param_value_or_default<int>("colormap", colormap_);
+
+  if(std::isnan(min_v_) && !std::isnan(max_v_)) {
+    min_v_ = 0;
+  }
 }
 
 ImageTransportImageStreamer::~ImageTransportImageStreamer()
@@ -89,19 +97,23 @@ void ImageTransportImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr
   cv::Mat img;
   try
   {
-    if (msg->encoding.find("F") != std::string::npos)
-    {
-      // scale floating point images
-      cv::Mat float_image_bridge = cv_bridge::toCvCopy(msg, msg->encoding)->image;
-      cv::Mat_<float> float_image = float_image_bridge;
-      double max_val;
-      cv::minMaxIdx(float_image, 0, &max_val);
+    if (msg->encoding.find("16") != std::string::npos || msg->encoding.find("F") != std::string::npos) {
+      cv::Mat image_bridge = cv_bridge::toCvCopy(msg, msg->encoding)->image;
 
-      if (max_val > 0)
-      {
-        float_image *= (255 / max_val);
+      double max_val, min_val;
+      if(std::isnan(min_v_) || std::isnan(min_v_)) {
+	cv::minMaxIdx(image_bridge, &min_val, &max_val);
+      } else {
+	min_val = min_v_;
+	max_val = max_v_; 
       }
-      img = float_image;
+
+      float scale = 255. / (max_val - min_val);
+      image_bridge.convertTo(img, CV_8U, scale, -min_val * scale);
+
+      if(colormap_ >= 0) {
+	cv::applyColorMap(img, img, colormap_);
+      }
     }
     else
     {

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -33,6 +33,11 @@ static bool ros_connection_logger(async_web_server_cpp::HttpServerRequestHandler
   try
   {
     forward(request, connection, begin, end);
+    if (__verbose)
+    {
+      ROS_INFO_STREAM("Request forwarded: " << request.uri);
+    }
+
     return true;
   }
   catch (std::exception &e)
@@ -64,6 +69,9 @@ WebVideoServer::WebVideoServer(ros::NodeHandle &nh, ros::NodeHandle &private_nh)
   private_nh.param("ros_threads", ros_threads_, 2);
   private_nh.param("publish_rate", publish_rate_, -1.0);
 
+  if(__verbose) {
+      ROS_INFO_STREAM("Starting with args server threads: " << server_threads << " ros_threads: " << ros_threads_);
+  }
   private_nh.param<std::string>("default_stream_type", __default_stream_type, "mjpeg");
 
   stream_types_["mjpeg"] = boost::shared_ptr<ImageStreamerType>(new MjpegStreamerType());
@@ -101,7 +109,7 @@ WebVideoServer::~WebVideoServer()
 void WebVideoServer::spin()
 {
   server_->run();
-  ROS_INFO_STREAM("Waiting For connections on " << address_ << ":" << port_);
+    ROS_INFO_STREAM("Waiting For connections on " << address_ << ":" << port_);
 
   ros::AsyncSpinner spinner(ros_threads_);
   spinner.start();
@@ -184,6 +192,10 @@ bool WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &requ
     streamer->start();
     boost::mutex::scoped_lock lock(subscriber_mutex_);
     image_subscribers_.push_back(streamer);
+      if (__verbose)
+      {
+          ROS_INFO_STREAM("Serving " << image_subscribers_.size() << " streams");
+      }
   }
   else
   {


### PR DESCRIPTION
**Public API Changes**
None. Adds http parameters min/max/colormap but all are optional

**Description**

- Support was added for u16 image types
- Allow the stream to specify the min/max values when converting to 8u for float and u16 images
- Allow the stream to additionally be colormapped

**Issues**
#99 