### PR TITLE
Fix Width & Height Bug

### DIFF
--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -112,9 +112,10 @@ void ImageTransportImageStreamer::imageCallback(const sensor_msgs::ImageConstPtr
     int input_width = img.cols;
     int input_height = img.rows;
 
-    
-    output_width_ = input_width;
-    output_height_ = input_height;
+    if (output_width_ == -1)
+      output_width_ = input_width;
+    if (output_height_ == -1)
+      output_height_ = input_height;
 
     if (invert_)
     {


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
Before this PR the user-specified width and height parameters were getting overridden by the image's default width and height, preventing user-specified re-sizing. This bug was introduced in [this commit](https://github.com/RobotWebTools/web_video_server/commit/dfc4bf08c7cd0a1623f66fa3be7589e59b82bebc). This PR addresses that bug by reverting to the functionality that user-specified width and height had before that commit.

<!-- Link relevant GitHub issues -->
In service of #119 .