### PR TITLE
Add QoS profile query parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(${PROJECT_NAME}
   src/ros_compressed_streamer.cpp
   src/jpeg_streamers.cpp
   src/png_streamers.cpp
+  src/utils.cpp
 )
 
 ament_target_dependencies(${PROJECT_NAME}

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -5,6 +5,7 @@
 #include <image_transport/image_transport.hpp>
 #include <image_transport/transport_hints.hpp>
 #include <opencv2/opencv.hpp>
+#include "web_video_server/utils.h"
 #include "async_web_server_cpp/http_server.hpp"
 #include "async_web_server_cpp/http_request.hpp"
 
@@ -66,6 +67,7 @@ protected:
   int output_height_;
   bool invert_;
   std::string default_transport_;
+  std::string qos_profile_name_;
 
   rclcpp::Time last_frame;
   cv::Mat output_size_image;

--- a/include/web_video_server/ros_compressed_streamer.h
+++ b/include/web_video_server/ros_compressed_streamer.h
@@ -29,6 +29,7 @@ private:
   rclcpp::Time last_frame;
   sensor_msgs::msg::CompressedImage::ConstSharedPtr last_msg;
   boost::mutex send_mutex_;
+  std::string qos_profile_name_;
 };
 
 class RosCompressedStreamerType : public ImageStreamerType

--- a/include/web_video_server/utils.h
+++ b/include/web_video_server/utils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <optional>
+#include "rmw/qos_profiles.h"
+
+namespace web_video_server
+{
+
+/**
+ * @brief Gets a QoS profile given an input name, if valid.
+ * @param name The name of the QoS profile name.
+ * @return An optional containing the matching QoS profile.
+ */
+std::optional<rmw_qos_profile_t> get_qos_profile_from_name(const std::string name);
+
+}  // namespace web_video_server

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -24,6 +24,7 @@ ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_
   output_height_ = request.get_query_param_value_or_default<int>("height", -1);
   invert_ = request.has_query_param("invert");
   default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
+  qos_profile_name_ = request.get_query_param_value_or_default("qos_profile", "default");
 }
 
 ImageTransportImageStreamer::~ImageTransportImageStreamer()
@@ -46,7 +47,23 @@ void ImageTransportImageStreamer::start()
       break;
     }
   }
-  image_sub_ = it_.subscribe(topic_, 1, &ImageTransportImageStreamer::imageCallback, this, &hints);
+
+  // Get QoS profile from query parameter
+  RCLCPP_INFO(nh_->get_logger(), "Streaming topic %s with QoS profile %s", topic_.c_str(), qos_profile_name_.c_str());
+  auto qos_profile = get_qos_profile_from_name(qos_profile_name_);
+  if (!qos_profile) {
+    qos_profile = rmw_qos_profile_default;
+    RCLCPP_ERROR(
+      nh_->get_logger(),
+      "Invalid QoS profile %s specified. Using default profile.",
+      qos_profile_name_.c_str());
+  }
+
+  // Create subscriber
+  using std::placeholders::_1;
+  image_sub_ = image_transport::create_subscription(
+      nh_.get(), topic_, std::bind(&ImageTransportImageStreamer::imageCallback, this, _1),
+      default_transport_, qos_profile.value());
 }
 
 void ImageTransportImageStreamer::initialize(const cv::Mat &)

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -60,9 +60,8 @@ void ImageTransportImageStreamer::start()
   }
 
   // Create subscriber
-  using std::placeholders::_1;
   image_sub_ = image_transport::create_subscription(
-      nh_.get(), topic_, std::bind(&ImageTransportImageStreamer::imageCallback, this, _1),
+      nh_.get(), topic_, std::bind(&ImageTransportImageStreamer::imageCallback, this, std::placeholders::_1),
       default_transport_, qos_profile.value());
 }
 

--- a/src/ros_compressed_streamer.cpp
+++ b/src/ros_compressed_streamer.cpp
@@ -8,6 +8,7 @@ RosCompressedStreamer::RosCompressedStreamer(const async_web_server_cpp::HttpReq
   ImageStreamer(request, connection, nh), stream_(std::bind(&rclcpp::Node::now, nh), connection)
 {
   stream_.sendInitialHeader();
+  qos_profile_name_ = request.get_query_param_value_or_default("qos_profile", "default");
 }
 
 RosCompressedStreamer::~RosCompressedStreamer()
@@ -17,9 +18,22 @@ RosCompressedStreamer::~RosCompressedStreamer()
 }
 
 void RosCompressedStreamer::start() {
-  std::string compressed_topic = topic_ + "/compressed";
+  // Get QoS profile from query parameter
+  RCLCPP_INFO(nh_->get_logger(), "Streaming topic %s with QoS profile %s", topic_.c_str(), qos_profile_name_.c_str());
+  auto qos_profile = get_qos_profile_from_name(qos_profile_name_);
+  if (!qos_profile) {
+    qos_profile = rmw_qos_profile_default;
+    RCLCPP_ERROR(
+      nh_->get_logger(),
+      "Invalid QoS profile %s specified. Using default profile.",
+      qos_profile_name_.c_str());
+  }
+
+  // Create subscriber
+  const std::string compressed_topic = topic_ + "/compressed";
+  const auto qos = rclcpp::QoS(rclcpp::QoSInitialization(qos_profile.value().history, 1), qos_profile.value());
   image_sub_ = nh_->create_subscription<sensor_msgs::msg::CompressedImage>(
-    compressed_topic, 1, std::bind(&RosCompressedStreamer::imageCallback, this, std::placeholders::_1));
+      compressed_topic, qos, std::bind(&RosCompressedStreamer::imageCallback, this, std::placeholders::_1));
 }
 
 void RosCompressedStreamer::restreamFrame(double max_age)

--- a/src/ros_compressed_streamer.cpp
+++ b/src/ros_compressed_streamer.cpp
@@ -18,8 +18,10 @@ RosCompressedStreamer::~RosCompressedStreamer()
 }
 
 void RosCompressedStreamer::start() {
+  const std::string compressed_topic = topic_ + "/compressed";
+
   // Get QoS profile from query parameter
-  RCLCPP_INFO(nh_->get_logger(), "Streaming topic %s with QoS profile %s", topic_.c_str(), qos_profile_name_.c_str());
+  RCLCPP_INFO(nh_->get_logger(), "Streaming topic %s with QoS profile %s", compressed_topic.c_str(), qos_profile_name_.c_str());
   auto qos_profile = get_qos_profile_from_name(qos_profile_name_);
   if (!qos_profile) {
     qos_profile = rmw_qos_profile_default;
@@ -30,7 +32,6 @@ void RosCompressedStreamer::start() {
   }
 
   // Create subscriber
-  const std::string compressed_topic = topic_ + "/compressed";
   const auto qos = rclcpp::QoS(rclcpp::QoSInitialization(qos_profile.value().history, 1), qos_profile.value());
   image_sub_ = nh_->create_subscription<sensor_msgs::msg::CompressedImage>(
       compressed_topic, qos, std::bind(&RosCompressedStreamer::imageCallback, this, std::placeholders::_1));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,26 @@
+#include "web_video_server/utils.h"
+
+namespace web_video_server
+{
+    
+std::optional<rmw_qos_profile_t> get_qos_profile_from_name(const std::string name)
+{
+  if (name == "default")
+  {
+    return rmw_qos_profile_default;
+  }
+  else if (name == "system_default")
+  {
+    return rmw_qos_profile_system_default;
+  }
+  else if (name == "sensor_data")
+  {
+    return rmw_qos_profile_sensor_data;
+  }
+  else
+  {
+    return std::nullopt;
+  }
+}
+
+}  // namespace web_video_server


### PR DESCRIPTION
**Public API Changes**
N/A

**Description**
This PR add a `qos_profile` query parameter that allows specifying a non-default (QoS) profile for the `ImageTransportImageStreamer` and `ROSCompressedStreamer` classes, which are the two that create ROS 2 subscribers with the default QoS profile.

For example, to use the [sensor data proflie](https://github.com/ros2/rmw/blob/rolling/rmw/include/rmw/qos_profiles.h#L25-L36), you could go to, e.g., the following URL:

```
http://localhost:8080/stream_viewer?topic=/camera/color/image_raw&qos_profile=sensor_data
```

This doesn't support all the profiles that exist in `rclcpp`, but maybe some of the common ones? It's easy enough to add more as people need them. For our use case at PickNik, we needed the `sensor_data` profile to get things working, so that's our motivation.