### PR TITLE
Add support for jpg compression format

### DIFF
--- a/src/ros_compressed_streamer.cpp
+++ b/src/ros_compressed_streamer.cpp
@@ -36,7 +36,7 @@ void RosCompressedStreamer::sendImage(const sensor_msgs::CompressedImageConstPtr
                                       const ros::Time &time) {
   try {
     std::string content_type;
-    if(msg->format.find("jpeg") != std::string::npos) {
+    if(msg->format.find("jpeg") != std::string::npos || msg->format.find("jpg") != std::string::npos) {
       content_type = "image/jpeg";
     }
     else if(msg->format.find("png") != std::string::npos) {


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None

**Description**
<!-- Describe what has changed, and motivation behind those changes -->
Add support for compressed ROS image messages with the format `jpg`, so that `jpg` images are treated the same way as `jpeg` images.

<!-- Link relevant GitHub issues -->
#139 