### PR TITLE
Use cv_bridge hpp headers when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ endif()
 ## Build ##
 ###########
 
+if(${cv_bridge_VERSION} VERSION_LESS "3.3.0")
+  add_compile_definitions(CV_BRIDGE_USES_OLD_HEADERS)
+endif()
+
 ## Specify additional locations of header files
 include_directories(include
   ${Boost_INCLUDE_DIRS}

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -2,7 +2,13 @@
 #define WEB_VIDEO_SERVER_H_
 
 #include <rclcpp/rclcpp.hpp>
+
+#ifdef CV_BRIDGE_USES_OLD_HEADERS
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
+
 #include <vector>
 #include "web_video_server/image_streamer.h"
 #include "async_web_server_cpp/http_server.hpp"

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -1,5 +1,11 @@
 #include "web_video_server/image_streamer.h"
+
+#ifdef CV_BRIDGE_USES_OLD_HEADERS
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
+
 #include <iostream>
 
 namespace web_video_server


### PR DESCRIPTION
Related to: #143

I'm trying to use a single branch for all currently supported ROS2 distros, hence the version check