### PR TITLE
Fix usage of deprecated libavcodec functions

### DIFF
--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -34,9 +34,9 @@ protected:
   virtual void initializeEncoder();
   virtual void sendImage(const cv::Mat&, const rclcpp::Time& time);
   virtual void initialize(const cv::Mat&);
-  AVOutputFormat* output_format_;
+  AVOutputFormat output_format_;
   AVFormatContext* format_context_;
-  AVCodec* codec_;
+  const AVCodec* codec_;
   AVCodecContext* codec_context_;
   AVStream* video_stream_;
 

--- a/include/web_video_server/libav_streamer.h
+++ b/include/web_video_server/libav_streamer.h
@@ -34,7 +34,6 @@ protected:
   virtual void initializeEncoder();
   virtual void sendImage(const cv::Mat&, const rclcpp::Time& time);
   virtual void initialize(const cv::Mat&);
-  AVOutputFormat output_format_;
   AVFormatContext* format_context_;
   const AVCodec* codec_;
   AVCodecContext* codec_context_;

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -139,9 +139,10 @@ void ImageTransportImageStreamer::imageCallback(const sensor_msgs::msg::Image::C
     int input_width = img.cols;
     int input_height = img.rows;
 
-    
-    output_width_ = input_width;
-    output_height_ = input_height;
+    if (output_width_ == -1)
+      output_width_ = input_width;
+    if (output_height_ == -1)
+      output_height_ = input_height;
 
     if (invert_)
     {

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -139,10 +139,9 @@ void ImageTransportImageStreamer::imageCallback(const sensor_msgs::msg::Image::C
     int input_width = img.cols;
     int input_height = img.rows;
 
-    if (output_width_ == -1)
-      output_width_ = input_width;
-    if (output_height_ == -1)
-      output_height_ = input_height;
+    
+    output_width_ = input_width;
+    output_height_ = input_height;
 
     if (invert_)
     {
@@ -171,8 +170,7 @@ void ImageTransportImageStreamer::imageCallback(const sensor_msgs::msg::Image::C
     }
 
     last_frame = nh_->now();
-    sendImage(output_size_image, last_frame );
-
+    sendImage(output_size_image, msg->header.stamp);
   }
   catch (cv_bridge::Exception &e)
   {

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -256,7 +256,7 @@ void LibavStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
     pkt->pts = (int64_t)(seconds / av_q2d(video_stream_->time_base) * 0.95);
     if (pkt->pts <= 0)
       pkt->pts = 1;
-    pkt->dts = AV_NOPTS_VALUE;
+    pkt->dts = pkt->pts;
 
     if (pkt->flags&AV_PKT_FLAG_KEY)
       pkt->flags |= AV_PKT_FLAG_KEY;

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -27,11 +27,7 @@ LibavStreamer::~LibavStreamer()
 {
   if (codec_context_)
   {
-    #if ( LIBAVCODEC_VERSION_INT  < AV_VERSION_INT(58,9,100) )
-    avcodec_close(codec_context_);
-    #else
     avcodec_free_context(&codec_context_);
-    #endif
   }
   if (frame_)
   {

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -202,7 +202,6 @@ void LibavStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
   {
     first_image_timestamp_ = time;
   }
-  std::vector<uint8_t> encoded_frame;
 
   AVPixelFormat input_coding_format = AV_PIX_FMT_BGR24;
 
@@ -280,14 +279,8 @@ void LibavStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
       throw std::runtime_error("Error when writing frame");
     }
   }
-  else
-  {
-    encoded_frame.clear();
-  }
 
   av_packet_unref(pkt);
-
-  connection_->write_and_clear(encoded_frame);
 }
 
 LibavStreamerType::LibavStreamerType(const std::string &format_name, const std::string &codec_name,

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -235,17 +235,14 @@ void LibavStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
   ret = avcodec_send_frame(codec_context_, frame_);
   if (ret == AVERROR_EOF)
   {
-    std::cerr << "avcodec_send_frame() encoder flushed\n";
-    // ROS_DEBUG_STREAM("avcodec_send_frame() encoder flushed");
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "avcodec_send_frame() encoder flushed\n"); 
   }
   else if (ret == AVERROR(EAGAIN))
   {
-    std::cerr << "avcodec_send_frame() need output read out\n";
-    // ROS_DEBUG_STREAM("avcodec_send_frame() need output read out");
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "avcodec_send_frame() need output read out\n"); 
   }
   if (ret < 0)
   {
-    // std::cerr << "Error encoding video frame\n";
     throw std::runtime_error("Error encoding video frame");
   }
 
@@ -253,13 +250,11 @@ void LibavStreamer::sendImage(const cv::Mat &img, const rclcpp::Time &time)
   bool got_packet = pkt->size > 0;
   if (ret == AVERROR_EOF)
   {
-    std::cerr << "avcodec_recieve_packet() encoder flushed\n";
-    // ROS_DEBUG_STREAM("avcodec_recieve_packet() encoder flushed");
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "avcodec_receive_packet() encoder flushed\n"); 
   }
   else if (ret == AVERROR(EAGAIN))
   {
-    std::cerr << "avcodec_recieve_packet() need more input\n";
-    // ROS_DEBUG_STREAM("avcodec_recieve_packet() need more input");
+    RCLCPP_DEBUG_STREAM(nh_->get_logger(), "avcodec_receive_packet() needs more input\n"); 
     got_packet = false;
   }
 


### PR DESCRIPTION
Fixes web_video_server for Jazzy and Rolling distributions. 

I also dropped backward compatibility with old ffmpeg libraries to make the code easier to maintain.