### PR TITLE
Image Streams Now Stop When Connection Closed (ROS2)

### DIFF
--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -200,7 +200,7 @@ void ImageTransportImageStreamer::imageCallback(const sensor_msgs::msg::Image::C
     }
 
     last_frame = node_->now();
-    sendImage(output_size_image, msg->header.stamp);
+    sendImage(output_size_image, last_frame);
   } catch (cv_bridge::Exception & e) {
     auto & clk = *node_->get_clock();
     RCLCPP_ERROR_THROTTLE(node_->get_logger(), clk, 40, "cv_bridge exception: %s", e.what());


### PR DESCRIPTION
WARNING: This has only been tested in ROS1. I have not confirmed the issue, compiled, or tested the fix in ROS2 yet. 

**Public API Changes**
None


**Description**
I have a setup where my camera and my host computer are using different time domains (camera time is significantly ahead of computer time). I'm using the jpeg image streamer to stream to a browser. I found that when I close the image stream window in my browser, the subscription was not getting closed.

This is because the isBusy() function was comparing image header time stamp to ros::Time::now() when checking if pending footers were too old and needed to be removed. It would never clear old footers from the queue, preventing it from sending new images. Preventing sending new images meant that exceptions would never bubble up from the async_web_server library to indicate a connection issue

Forcing all time stamping to use ros::Time::now() instead of camera time fixed this issue because there was no longer a time domain mismatch. I chose to use system time instead of image header time because the restreamFrame() function also needs to make a timeout decision, but does not have an image header to compare to. It would be possible to use image header time all the way through by saving the latest image header timestamp, but it doesn't seem beneficial because there is no consumer for accurate camera timestamps from what I can tell. Maybe some of the other image streams care about this?

https://github.com/RobotWebTools/web_video_server/issues/171