### PR TITLE
Add pkg-config dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <author email="mwills@wpi.edu">Mitchell Wills</author>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>


### PR DESCRIPTION
**Public API Changes**

None


**Description**

Added `pkg-config` as `buildtool_depend` since it´s needed to build the package. 


<!-- Link relevant GitHub issues -->
