### PR TITLE
Fix URL-encoded slashes in topic names

### DIFF
--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include <iostream>
+#include <regex>
 
 namespace web_video_server
 {
@@ -46,7 +47,7 @@ ImageStreamer::ImageStreamer(
   async_web_server_cpp::HttpConnectionPtr connection, rclcpp::Node::SharedPtr node)
 : request_(request), connection_(connection), node_(node), inactive_(false)
 {
-  topic_ = request.get_query_param_value_or_default("topic", "");
+  topic_ = std::regex_replace(request.get_query_param_value_or_default("topic", ""), std::regex(R"(%2F)"), "/");
 }
 
 ImageStreamer::~ImageStreamer()

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -32,6 +32,7 @@
 
 #include <chrono>
 #include <vector>
+#include <regex>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <opencv2/opencv.hpp>
@@ -172,7 +173,7 @@ bool WebVideoServer::handle_stream(
 {
   std::string type = request.get_query_param_value_or_default("type", default_stream_type_);
   if (stream_types_.find(type) != stream_types_.end()) {
-    std::string topic = request.get_query_param_value_or_default("topic", "");
+    std::string topic = std::regex_replace(request.get_query_param_value_or_default("topic", ""), std::regex(R"(%2F)"), "/");
     // Fallback for topics without corresponding compressed topics
     if (type == std::string("ros_compressed")) {
       std::string compressed_topic_name = topic + "/compressed";


### PR DESCRIPTION
**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
None?

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

Technically, if your query parameter includes a `/`, it's supposed to be URL-encoded as `%2F`. I started using a library that makes this mandatory in my UI codebase, so web_video_server stopped working for me because it doesn't do any URL decoding - and my topics are called things like `/wrist_camera/depth`, thus becoming `%2Fwrist_camera%2Fdepth`.

A more complete solution here would be to actually decode the URL component entirely, but this unblocked me so I figured I'd open a PR just in case nobody wanted to introduce an additional library dependency to decode a URL, which I assume would be the case.

<!-- Link relevant GitHub issues -->
