### PR TITLE
Enable grayscale encoding in LibavStreamer

### DIFF
--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -148,10 +148,6 @@ cv::Mat ImageTransportImageStreamer::decodeImage(
     cv::Mat_<float> float_image = float_image_bridge;
     double max_val;
     cv::minMaxIdx(float_image, 0, &max_val);
-
-    if (max_val > 0) {
-      float_image *= (255 / max_val);
-    }
     return float_image;
   } else {
     // Convert to OpenCV native BGR color

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -225,7 +225,13 @@ void LibavStreamer::sendImage(
     first_image_time_ = time;
   }
 
-  AVPixelFormat input_coding_format = AV_PIX_FMT_BGR24;
+  AVPixelFormat input_coding_format;
+  if (img.channels() == 1) {
+    img.convertTo(img, CV_32FC1);
+    input_coding_format = AV_PIX_FMT_GRAYF32;
+  } else {
+    input_coding_format = AV_PIX_FMT_BGR24;
+  }
 
   AVFrame * raw_frame = av_frame_alloc();
   av_image_fill_arrays(


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Encode single channel images properly


<!-- Link relevant GitHub issues -->
resolves https://github.com/RobotWebTools/web_video_server/issues/178