### PR TITLE
Checking the QoS of a publisher before connecting a subscriber.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(${PROJECT_NAME}
   src/ros_compressed_streamer.cpp
   src/jpeg_streamers.cpp
   src/png_streamers.cpp
+  src/utils.cpp
 )
 
 ament_target_dependencies(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ pkg_check_modules(avutil libavutil REQUIRED)
 pkg_check_modules(swscale libswscale REQUIRED)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 ###################################################

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -5,6 +5,7 @@
 #include <image_transport/image_transport.hpp>
 #include <image_transport/transport_hints.hpp>
 #include <opencv2/opencv.hpp>
+#include "web_video_server/utils.h"
 #include "async_web_server_cpp/http_server.hpp"
 #include "async_web_server_cpp/http_request.hpp"
 
@@ -66,6 +67,7 @@ protected:
   int output_height_;
   bool invert_;
   std::string default_transport_;
+  std::string qos_profile_name_;
 
   rclcpp::Time last_frame;
   cv::Mat output_size_image;

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -1,7 +1,9 @@
 #ifndef IMAGE_STREAMER_H_
 #define IMAGE_STREAMER_H_
 
-#include <rclcpp/rclcpp.hpp>
+#include "async_web_server_cpp/http_request.hpp"
+#include "async_web_server_cpp/http_server.hpp"
+#include "web_video_server/utils.h"
 #include <image_transport/image_transport.hpp>
 #include <image_transport/transport_hints.hpp>
 #include <opencv2/opencv.hpp>
@@ -61,6 +63,19 @@ protected:
   virtual void sendImage(const cv::Mat &, const rclcpp::Time &time) = 0;
   virtual void restreamFrame(double max_age);
   virtual void initialize(const cv::Mat &);
+
+  /**
+   * @brief Detects QoS profile settings used by publishers on a specified topic.
+   * 
+   * This function queries the ROS2 middleware to discover publishers on the 
+   * given topic and extracts their QoS profile settings. It's useful for 
+   * creating subscribers that automatically match the publisher's QoS.
+   * 
+   * @param topic_name The full name of the topic to query.
+   * @return std::optional<rmw_qos_profile_t> The detected QoS profile if a publisher
+   *         is found, std::nullopt otherwise
+   */
+  std::optional<rmw_qos_profile_t> detect_publisher_qos(const std::string &topic_name);
 
   image_transport::Subscriber image_sub_;
   int output_width_;

--- a/include/web_video_server/ros_compressed_streamer.h
+++ b/include/web_video_server/ros_compressed_streamer.h
@@ -29,6 +29,7 @@ private:
   rclcpp::Time last_frame;
   sensor_msgs::msg::CompressedImage::ConstSharedPtr last_msg;
   boost::mutex send_mutex_;
+  std::string qos_profile_name_;
 };
 
 class RosCompressedStreamerType : public ImageStreamerType

--- a/include/web_video_server/utils.h
+++ b/include/web_video_server/utils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <optional>
+#include "rmw/qos_profiles.h"
+
+namespace web_video_server
+{
+
+/**
+ * @brief Gets a QoS profile given an input name, if valid.
+ * @param name The name of the QoS profile name.
+ * @return An optional containing the matching QoS profile.
+ */
+std::optional<rmw_qos_profile_t> get_qos_profile_from_name(const std::string name);
+
+}  // namespace web_video_server

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -24,6 +24,7 @@ ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_
   output_height_ = request.get_query_param_value_or_default<int>("height", -1);
   invert_ = request.has_query_param("invert");
   default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
+  qos_profile_name_ = request.get_query_param_value_or_default("qos_profile", "default");
 }
 
 ImageTransportImageStreamer::~ImageTransportImageStreamer()
@@ -46,7 +47,23 @@ void ImageTransportImageStreamer::start()
       break;
     }
   }
-  image_sub_ = it_.subscribe(topic_, 1, &ImageTransportImageStreamer::imageCallback, this, &hints);
+
+  // Get QoS profile from query parameter
+  RCLCPP_INFO(nh_->get_logger(), "Streaming topic %s with QoS profile %s", topic_.c_str(), qos_profile_name_.c_str());
+  auto qos_profile = get_qos_profile_from_name(qos_profile_name_);
+  if (!qos_profile) {
+    qos_profile = rmw_qos_profile_default;
+    RCLCPP_ERROR(
+      nh_->get_logger(),
+      "Invalid QoS profile %s specified. Using default profile.",
+      qos_profile_name_.c_str());
+  }
+
+  // Create subscriber
+  using std::placeholders::_1;
+  image_sub_ = image_transport::create_subscription(
+      nh_.get(), topic_, std::bind(&ImageTransportImageStreamer::imageCallback, this, _1),
+      default_transport_, qos_profile.value());
 }
 
 void ImageTransportImageStreamer::initialize(const cv::Mat &)

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -24,11 +24,58 @@ ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_
   output_height_ = request.get_query_param_value_or_default<int>("height", -1);
   invert_ = request.has_query_param("invert");
   default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
-  qos_profile_name_ = request.get_query_param_value_or_default("qos_profile", "default");
+  qos_profile_name_ = request.get_query_param_value_or_default("qos_profile", "auto");
 }
 
 ImageTransportImageStreamer::~ImageTransportImageStreamer()
 {
+}
+
+std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::detect_publisher_qos(const std::string &topic_name) 
+{
+  RCLCPP_INFO(nh_->get_logger(), "Attempting to auto-detect QoS for topic: %s", topic_name.c_str());
+
+  auto topic_endpoint_info_array = nh_->get_publishers_info_by_topic(topic_name);
+  if (topic_endpoint_info_array.empty()) {
+    RCLCPP_WARN(nh_->get_logger(), "No publishers found for topic: %s", topic_name.c_str());
+    return std::nullopt;
+  }
+
+  // Use the first publisher's QoS as reference.
+  auto endpoint_info = topic_endpoint_info_array.front();
+  auto qos_profile = endpoint_info.qos_profile();
+
+  // Log the detected QoS settings.
+  std::string reliability =
+      (qos_profile.reliability() == rclcpp::ReliabilityPolicy::Reliable) ? "RELIABLE" : "BEST_EFFORT";
+  std::string durability =
+      (qos_profile.durability() == rclcpp::DurabilityPolicy::TransientLocal) ? "TRANSIENT_LOCAL" : "VOLATILE";
+
+  RCLCPP_INFO(nh_->get_logger(), "Detected QoS - Reliability: %s, Durability: %s, History depth: %zu",
+              reliability.c_str(), durability.c_str(), qos_profile.depth());
+
+  // Convert rclcpp QoS to rmw QoS profile.
+  rmw_qos_profile_t rmw_qos = rmw_qos_profile_default;
+
+  // Set reliability
+  if (qos_profile.reliability() == rclcpp::ReliabilityPolicy::Reliable) {
+    rmw_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  } else {
+    rmw_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  }
+
+  // Set durability
+  if (qos_profile.durability() == rclcpp::DurabilityPolicy::TransientLocal) {
+    rmw_qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+  } else {
+    rmw_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+  }
+
+  // Set history policy and depth
+  rmw_qos.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+  rmw_qos.depth = qos_profile.depth();
+
+  return rmw_qos;
 }
 
 void ImageTransportImageStreamer::start()
@@ -48,15 +95,29 @@ void ImageTransportImageStreamer::start()
     }
   }
 
-  // Get QoS profile from query parameter
-  RCLCPP_INFO(nh_->get_logger(), "Streaming topic %s with QoS profile %s", topic_.c_str(), qos_profile_name_.c_str());
-  auto qos_profile = get_qos_profile_from_name(qos_profile_name_);
-  if (!qos_profile) {
-    qos_profile = rmw_qos_profile_default;
-    RCLCPP_ERROR(
-      nh_->get_logger(),
-      "Invalid QoS profile %s specified. Using default profile.",
-      qos_profile_name_.c_str());
+  // Get QoS profile based on user selection or auto-detect
+  std::optional<rmw_qos_profile_t> qos_profile;
+
+  qos_profile_name_ = "auto";
+  if (qos_profile_name_ == "auto") {
+    // Auto-detect QoS from publisher
+    qos_profile = detect_publisher_qos(topic_);
+    if (!qos_profile) {
+      RCLCPP_WARN(nh_->get_logger(), "Could not auto-detect QoS for topic %s. Using default profile.", topic_.c_str());
+      qos_profile = rmw_qos_profile_default;
+    } else {
+      RCLCPP_INFO(nh_->get_logger(), "Using auto-detected QoS profile for topic %s", topic_.c_str());
+    }
+  } else {
+    // Use named profile
+    RCLCPP_INFO(nh_->get_logger(), "Using specified QoS profile %s for topic %s", qos_profile_name_.c_str(),
+                topic_.c_str());
+    qos_profile = get_qos_profile_from_name(qos_profile_name_);
+    if (!qos_profile) {
+      qos_profile = rmw_qos_profile_default;
+      RCLCPP_ERROR(nh_->get_logger(), "Invalid QoS profile %s specified. Using default profile.",
+                   qos_profile_name_.c_str());
+    }
   }
 
   // Create subscriber

--- a/src/ros_compressed_streamer.cpp
+++ b/src/ros_compressed_streamer.cpp
@@ -8,6 +8,7 @@ RosCompressedStreamer::RosCompressedStreamer(const async_web_server_cpp::HttpReq
   ImageStreamer(request, connection, nh), stream_(std::bind(&rclcpp::Node::now, nh), connection)
 {
   stream_.sendInitialHeader();
+  qos_profile_name_ = request.get_query_param_value_or_default("qos_profile", "default");
 }
 
 RosCompressedStreamer::~RosCompressedStreamer()
@@ -17,9 +18,22 @@ RosCompressedStreamer::~RosCompressedStreamer()
 }
 
 void RosCompressedStreamer::start() {
-  std::string compressed_topic = topic_ + "/compressed";
+  // Get QoS profile from query parameter
+  RCLCPP_INFO(nh_->get_logger(), "Streaming topic %s with QoS profile %s", topic_.c_str(), qos_profile_name_.c_str());
+  auto qos_profile = get_qos_profile_from_name(qos_profile_name_);
+  if (!qos_profile) {
+    qos_profile = rmw_qos_profile_default;
+    RCLCPP_ERROR(
+      nh_->get_logger(),
+      "Invalid QoS profile %s specified. Using default profile.",
+      qos_profile_name_.c_str());
+  }
+
+  // Create subscriber
+  const std::string compressed_topic = topic_ + "/compressed";
+  const auto qos = rclcpp::QoS(rclcpp::QoSInitialization(qos_profile.value().history, 1), qos_profile.value());
   image_sub_ = nh_->create_subscription<sensor_msgs::msg::CompressedImage>(
-    compressed_topic, 1, std::bind(&RosCompressedStreamer::imageCallback, this, std::placeholders::_1));
+      compressed_topic, qos, std::bind(&RosCompressedStreamer::imageCallback, this, std::placeholders::_1));
 }
 
 void RosCompressedStreamer::restreamFrame(double max_age)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,26 @@
+#include "web_video_server/utils.h"
+
+namespace web_video_server
+{
+    
+std::optional<rmw_qos_profile_t> get_qos_profile_from_name(const std::string name)
+{
+  if (name == "default")
+  {
+    return rmw_qos_profile_default;
+  }
+  else if (name == "system_default")
+  {
+    return rmw_qos_profile_system_default;
+  }
+  else if (name == "sensor_data")
+  {
+    return rmw_qos_profile_sensor_data;
+  }
+  else
+  {
+    return std::nullopt;
+  }
+}
+
+}  // namespace web_video_server

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -54,7 +54,8 @@ WebVideoServer::WebVideoServer(rclcpp::Node::SharedPtr &nh, rclcpp::Node::Shared
         async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found))
 {
   rclcpp::Parameter parameter;
-  if (private_nh->get_parameter("port", parameter)) {
+  nh->declare_parameter("port", rclcpp::PARAMETER_INTEGER);
+  if (nh->get_parameter("port", parameter)) {
     port_ = parameter.as_int();
   } else {
     port_ = 8080;


### PR DESCRIPTION
In this PR we introduce a feature to inspect the publisher QoS before connecting a subscriber.

This is particularly useful when we have a Publisher that uses the QoS durability **Transient Local**. With this configuration, a publisher retains the last frame in a cache. When a subscriber connects to this kind of publisher, it is notified of the last image cached.

This is usually not desirable for a publisher that sends images at a high rate, where QoS **Volatile** is preferable. But it is useful in topics with a very low frame rate.
