### PR TITLE
Fix to build with current FFmpeg avformat

### DIFF
--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -77,7 +77,7 @@ LibavStreamer::~LibavStreamer()
 }
 
 // output callback for ffmpeg IO context
-static int dispatch_output_packet(void * opaque, uint8_t * buffer, int buffer_size)
+static int dispatch_output_packet(void * opaque, const uint8_t * buffer, int buffer_size)
 {
   async_web_server_cpp::HttpConnectionPtr connection =
     *((async_web_server_cpp::HttpConnectionPtr *) opaque);

--- a/src/libav_streamer.cpp
+++ b/src/libav_streamer.cpp
@@ -77,7 +77,11 @@ LibavStreamer::~LibavStreamer()
 }
 
 // output callback for ffmpeg IO context
+#if LIBAVFORMAT_VERSION_MAJOR < 61
+static int dispatch_output_packet(void * opaque, uint8_t * buffer, int buffer_size)
+#else
 static int dispatch_output_packet(void * opaque, const uint8_t * buffer, int buffer_size)
+#endif
 {
   async_web_server_cpp::HttpConnectionPtr connection =
     *((async_web_server_cpp::HttpConnectionPtr *) opaque);


### PR DESCRIPTION
**Public API Changes**
None


**Description**
    signature for function libavformat/avio.h avio_alloc_context, parameter write_packet has changed from
    (void *opaque, uint8_t *buf, int buf_size) to (void *opaque, const uint8_t *buf, int buf_size)
    This was previously deprecated, but removed on March 07, 2024.
    Please see https://github.com/FFmpeg/FFmpeg/commit/02aea61d69d8f81bc285e2131bf25f96a3e27feb
    for details.
    This commit reflects that change.

**Tested**
Tested on Ubuntu 22.04.5 LTS, RoboStack Jazzy on a Dell Intel machine and also on Raspberry Pi 3B+ Ubuntu 22.04.5 LTS, RoboStack Jazzy.

<!-- Link relevant GitHub issues -->
See Issue: https://github.com/RobotWebTools/web_video_server/issues/188