### PR TITLE
feat: Add shutdown handler for client to call and close alive sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,35 @@ http://localhost:8080/snapshot?topic=/camera/image_raw
 | `default_transport` | string | "raw" | "raw", "compressed", "theora" | Image transport to use |
 | `qos_profile` | string | "default" | "default", "system_default", "sensor_data", "services_default" | QoS profile for ROS 2 subscribers |
 
+### Stop an Active Stream
+
+To stop one or more active streams from the server side (e.g. when a UI component unmounts), use the `/shutdown` endpoint:
+
+```
+http://localhost:8080/shutdown?topic=/camera/image_raw
+```
+
+This closes all active streams for the given topic. An optional `client_id` parameter scopes the shutdown to a single named connection:
+
+```
+http://localhost:8080/shutdown?topic=/camera/image_raw&client_id=my-ui
+```
+
+To associate a stream with a `client_id`, pass it when opening the stream:
+
+```
+http://localhost:8080/stream?topic=/camera/image_raw&client_id=my-ui
+```
+
+The response is plain text in the form `stopped=<count>`, where `<count>` is the number of streams that were stopped. Returns `400 Bad Request` if `topic` is omitted.
+
+#### URL Parameters for Shutdown
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `topic` | string | (required) | The ROS topic whose streams should be stopped |
+| `client_id` | string | (none) | If provided, only the stream with this client_id is stopped |
+
 ## Creating custom streamer plugins
 See the [custom streamer plugin tutorial](doc/custom-streamer-plugin.md) for information on how to write your own streamer plugins.
 

--- a/include/web_video_server/streamer.hpp
+++ b/include/web_video_server/streamer.hpp
@@ -82,10 +82,7 @@ public:
   /**
    * @brief Returns the client_id associated with this stream, or an empty string if none.
    */
-  virtual std::string get_client_id()
-  {
-    return "";
-  }
+  virtual std::string get_client_id() = 0;
 };
 
 /**

--- a/include/web_video_server/streamer.hpp
+++ b/include/web_video_server/streamer.hpp
@@ -59,7 +59,7 @@ public:
   /**
    * @brief Stops the streaming process and marks the streamer as inactive.
    */
-  virtual void stop() {}
+  virtual void stop() = 0;
 
   /**
    * @brief Returns true if the streamer is inactive and should be deleted.

--- a/include/web_video_server/streamer.hpp
+++ b/include/web_video_server/streamer.hpp
@@ -57,6 +57,11 @@ public:
   virtual void start() = 0;
 
   /**
+   * @brief Stops the streaming process and marks the streamer as inactive.
+   */
+  virtual void stop() {}
+
+  /**
    * @brief Returns true if the streamer is inactive and should be deleted.
    *
    * This could be because the connection was closed or snapshot was successfully sent (in case
@@ -73,6 +78,14 @@ public:
    * @brief Returns the topic being streamed.
    */
   virtual std::string get_topic() = 0;
+
+  /**
+   * @brief Returns the client_id associated with this stream, or an empty string if none.
+   */
+  virtual std::string get_client_id()
+  {
+    return "";
+  }
 };
 
 /**
@@ -87,6 +100,12 @@ public:
     rclcpp::Node::WeakPtr node,
     std::string logger_name = "streamer");
 
+  void stop() override
+  {
+    inactive_ = true;
+    connection_.reset();
+  }
+
   bool is_inactive() override
   {
     return inactive_;
@@ -95,6 +114,11 @@ public:
   std::string get_topic() override
   {
     return topic_;
+  }
+
+  std::string get_client_id() override
+  {
+    return client_id_;
   }
 
 protected:
@@ -106,6 +130,7 @@ protected:
   rclcpp::Logger logger_;
   bool inactive_;
   std::string topic_;
+  std::string client_id_;
 };
 
 /**

--- a/include/web_video_server/web_video_server.hpp
+++ b/include/web_video_server/web_video_server.hpp
@@ -89,6 +89,11 @@ public:
     async_web_server_cpp::HttpConnectionPtr connection,
     const char * begin, const char * end);
 
+  bool handle_shutdown(
+    const async_web_server_cpp::HttpRequest & request,
+    async_web_server_cpp::HttpConnectionPtr connection,
+    const char * begin, const char * end);
+
   bool handle_list_streams(
     const async_web_server_cpp::HttpRequest & request,
     async_web_server_cpp::HttpConnectionPtr connection,

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -51,7 +51,8 @@ StreamerBase::StreamerBase(
   std::string logger_name)
 : connection_(connection), request_(request), node_(std::move(node)),
   logger_(node_.lock()->get_logger().get_child(logger_name)), inactive_(false),
-  topic_(request.get_query_param_value_or_default("topic", ""))
+  topic_(request.get_query_param_value_or_default("topic", "")),
+  client_id_(request.get_query_param_value_or_default("client_id", ""))
 {
 }
 

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -120,6 +120,9 @@ WebVideoServer::WebVideoServer(const rclcpp::NodeOptions & options)
   handler_group_.addHandlerForPath(
     "/snapshot",
     boost::bind(&WebVideoServer::handle_snapshot, this, _1, _2, _3, _4));
+  handler_group_.addHandlerForPath(
+    "/shutdown",
+    boost::bind(&WebVideoServer::handle_shutdown, this, _1, _2, _3, _4));
 
   try {
     server_.reset(
@@ -260,6 +263,49 @@ bool WebVideoServer::handle_stream_viewer(
     async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found)(
       request, connection, begin, end);
   }
+  return true;
+}
+
+bool WebVideoServer::handle_shutdown(
+  const async_web_server_cpp::HttpRequest & request,
+  async_web_server_cpp::HttpConnectionPtr connection, const char * begin,
+  const char * end)
+{
+  const std::string topic = request.get_query_param_value_or_default("topic", "");
+  if (topic.empty()) {
+    async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::bad_request)(
+      request, connection, begin, end);
+    return true;
+  }
+
+  const std::string client_id = request.get_query_param_value_or_default("client_id", "");
+
+  int stopped = 0;
+  {
+    const std::scoped_lock lock(streamers_mutex_);
+    for (auto & streamer : streamers_) {
+      if (streamer->get_topic() == topic) {
+        if (client_id.empty() || streamer->get_client_id() == client_id) {
+          streamer->stop();
+          ++stopped;
+        }
+      }
+    }
+  }
+
+  if (verbose_) {
+    RCLCPP_INFO(
+      get_logger(), "Shutdown request for topic '%s' (client_id='%s'): stopped %d stream(s)",
+      topic.c_str(), client_id.c_str(), stopped);
+  }
+
+  async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok)
+  .header("Connection", "close")
+  .header("Server", "web_video_server")
+  .header("Content-type", "text/plain;")
+  .write(connection);
+
+  connection->write("stopped=" + std::to_string(stopped));
   return true;
 }
 

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -294,9 +294,10 @@ bool WebVideoServer::handle_shutdown(
   }
 
   if (verbose_) {
+    const std::string client_id_info = client_id.empty() ? "" : " (client_id='" + client_id + "')";
     RCLCPP_INFO(
-      get_logger(), "Shutdown request for topic '%s' (client_id='%s'): stopped %d stream(s)",
-      topic.c_str(), client_id.c_str(), stopped);
+      get_logger(), "Shutdown request for topic '%s'%s: stopped %d stream(s)",
+      topic.c_str(), client_id_info.c_str(), stopped);
   }
 
   async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok)


### PR DESCRIPTION
Add TCP port socket shutdown if not alive

**Public API Changes**
<!-- Describe any changes to the public API, or write "None" -->
Add shutdown handler for clients **/shutdown**

**Description**
<!-- Describe what has changed, and motivation behind those changes -->

1. Added changes for shutdown handler and api
2. Added readme usage instructions
3. tested on local javascipt UI


<!-- Link relevant GitHub issues -->
https://github.com/RobotWebTools/web_video_server/issues/193