### PR TITLE
refactor: Add clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: >
-  -clang-analyzer-*,
+  clang-analyzer-*,
+  -clang-analyzer-optin.cplusplus.VirtualCall,
   clang-diagnostic-*,
   google-*,
   misc-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,9 +2,11 @@
 Checks: >
   -clang-analyzer-*,
   -clang-diagnostic-*,
+  misc-include-cleaner,
   readability-identifier-naming,
 
 CheckOptions:
+  misc-include-cleaner.IgnoreHeaders: bits/chrono.h
   readability-identifier-naming.ClassCase: CamelCase
   readability-identifier-naming.ClassMemberCase: lower_case
   readability-identifier-naming.ConstexprVariableCase: CamelCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,8 @@
 ---
 Checks: >
   -clang-analyzer-*,
-  -clang-diagnostic-*,
+  clang-diagnostic-*,
+  google-*,
   misc-include-cleaner,
   readability-identifier-naming,
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,30 @@
+---
+Checks: >
+  -clang-analyzer-*,
+  -clang-diagnostic-*,
+  readability-identifier-naming,
+
+CheckOptions:
+  readability-identifier-naming.ClassCase: CamelCase
+  readability-identifier-naming.ClassMemberCase: lower_case
+  readability-identifier-naming.ConstexprVariableCase: CamelCase
+  readability-identifier-naming.EnumCase: CamelCase
+  readability-identifier-naming.EnumConstantCase: CamelCase
+  readability-identifier-naming.FunctionCase: lower_case
+  readability-identifier-naming.GlobalConstantCase: CamelCase
+  readability-identifier-naming.StaticConstantCase: CamelCase
+  readability-identifier-naming.StaticVariableCase: lower_case
+  readability-identifier-naming.MacroDefinitionCase: UPPER_CASE
+  readability-identifier-naming.MacroDefinitionIgnoredRegexp: '^[A-Z]+(_[A-Z]+)*_$'
+  readability-identifier-naming.PrivateMemberCase: lower_case
+  readability-identifier-naming.ProtectedMemberCase: lower_case
+  readability-identifier-naming.PublicMemberCase: lower_case
+  readability-identifier-naming.PrivateMemberSuffix: _
+  readability-identifier-naming.ProtectedMemberSuffix: _
+  readability-identifier-naming.PublicMemberSuffix: ''
+  readability-identifier-naming.NamespaceCase: lower_case
+  readability-identifier-naming.ParameterCase: lower_case
+  readability-identifier-naming.TypeAliasCase: CamelCase
+  readability-identifier-naming.TypedefCase: CamelCase
+  readability-identifier-naming.VariableCase: lower_case
+  readability-identifier-naming.IgnoreMainLikeFunctions: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,10 +4,13 @@ Checks: >
   clang-diagnostic-*,
   google-*,
   misc-include-cleaner,
-  readability-identifier-naming,
+  readability-*,
+  -readability-identifier-length,
+  -readability-magic-numbers,
 
 CheckOptions:
   misc-include-cleaner.IgnoreHeaders: bits/chrono.h
+  readability-function-cognitive-complexity.IgnoreMacros: true
   readability-identifier-naming.ClassCase: CamelCase
   readability-identifier-naming.ClassMemberCase: lower_case
   readability-identifier-naming.ConstexprVariableCase: CamelCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,7 +3,8 @@ Checks: >
   -clang-analyzer-*,
   clang-diagnostic-*,
   google-*,
-  misc-include-cleaner,
+  misc-*,
+  -misc-non-private-member-variables-in-classes,
   readability-*,
   -readability-identifier-length,
   -readability-magic-numbers,
@@ -18,7 +19,7 @@ CheckOptions:
   readability-identifier-naming.EnumConstantCase: CamelCase
   readability-identifier-naming.FunctionCase: lower_case
   readability-identifier-naming.GlobalConstantCase: CamelCase
-  readability-identifier-naming.StaticConstantCase: CamelCase
+  readability-identifier-naming.StaticConstantCase: lower_case
   readability-identifier-naming.StaticVariableCase: lower_case
   readability-identifier-naming.MacroDefinitionCase: UPPER_CASE
   readability-identifier-naming.MacroDefinitionIgnoredRegexp: '^[A-Z]+(_[A-Z]+)*_$'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [humble, jazzy, kilted]
+        ROS_DISTRO: [humble, jazzy, kilted, rolling]
         ROS_REPO: [testing, main]
-        include:
-          - ROS_DISTRO: rolling
-            ROS_REPO: testing
-            CMAKE_ARGS: "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_CLANG_TIDY=ON"
-          - ROS_DISTRO: rolling
-            ROS_REPO: main
-            CMAKE_ARGS: "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_CLANG_TIDY=ON"
     env:
       ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
       ROS_REPO: ${{ matrix.ROS_REPO }}
-      CMAKE_ARGS: ${{ matrix.CMAKE_ARGS }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Source tests
+        if: ${{ matrix.ROS_DISTRO != 'rolling' }}
         uses: "ros-industrial/industrial_ci@master"
+      - name: Source tests (with clang-tidy)
+        if: ${{ matrix.ROS_DISTRO == 'rolling' }}
+        uses: "ros-industrial/industrial_ci@master"
+        env:
+          CMAKE_ARGS: "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_CLANG_TIDY=ON"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Source tests
         uses: "ros-industrial/industrial_ci@master"
+        env:
+          CMAKE_ARGS: "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,9 @@ jobs:
     env:
       ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
       ROS_REPO: ${{ matrix.ROS_REPO }}
+      CMAKE_ARGS: ${{ matrix.ROS_DISTRO == 'rolling' && '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_CLANG_TIDY=ON' || '' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Source tests
-        if: ${{ matrix.ROS_DISTRO != 'rolling' }}
         uses: "ros-industrial/industrial_ci@master"
-      - name: Source tests (with clang-tidy)
-        if: ${{ matrix.ROS_DISTRO == 'rolling' }}
-        uses: "ros-industrial/industrial_ci@master"
-        env:
-          CMAKE_ARGS: "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_CLANG_TIDY=ON"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [humble, jazzy, kilted, rolling]
+        ROS_DISTRO: [humble, jazzy, kilted]
         ROS_REPO: [testing, main]
+        include:
+          - ROS_DISTRO: rolling
+            ROS_REPO: testing
+            CMAKE_ARGS: "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_CLANG_TIDY=ON"
+          - ROS_DISTRO: rolling
+            ROS_REPO: main
+            CMAKE_ARGS: "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_CLANG_TIDY=ON"
     env:
       ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
       ROS_REPO: ${{ matrix.ROS_REPO }}
+      CMAKE_ARGS: ${{ matrix.CMAKE_ARGS }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Source tests
         uses: "ros-industrial/industrial_ci@master"
-        env:
-          CMAKE_ARGS: "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,10 @@ if(BUILD_TESTING)
     )
   endif()
 
+  include(ProcessorCount)
+  processorcount(N)
+  set(ament_cmake_clang_tidy_JOBS ${N})
+
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,14 @@ if(BUILD_TESTING)
     )
   endif()
 
+  # Skip ament_clang_tidy check for all distros except rolling
+  # to avoid issues with multiple versions of clang being used
+  if(NOT $ENV{ROS_DISTRO} STREQUAL "rolling")
+    list(APPEND AMENT_LINT_AUTO_EXCLUDE
+      ament_cmake_clang_tidy
+    )
+  endif()
+
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,17 +165,16 @@ if(BUILD_TESTING)
     )
   endif()
 
-  # Skip ament_clang_tidy check for all distros except rolling
-  # to avoid issues with multiple versions of clang being used
-  if(NOT $ENV{ROS_DISTRO} STREQUAL "rolling")
+  option(ENABLE_CLANG_TIDY "Enable ament_clang_tidy test" OFF)
+  if(ENABLE_CLANG_TIDY)
+    include(ProcessorCount)
+    processorcount(N)
+    set(ament_cmake_clang_tidy_JOBS ${N})
+  else()
     list(APPEND AMENT_LINT_AUTO_EXCLUDE
       ament_cmake_clang_tidy
     )
   endif()
-
-  include(ProcessorCount)
-  processorcount(N)
-  set(ament_cmake_clang_tidy_JOBS ${N})
 
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/include/web_video_server/multipart_stream.hpp
+++ b/include/web_video_server/multipart_stream.hpp
@@ -56,7 +56,7 @@ struct PendingFooter
 class MultipartStream
 {
 public:
-  MultipartStream(
+  explicit MultipartStream(
     async_web_server_cpp::HttpConnectionPtr & connection,
     const std::string & boundary = "boundarydonotcross",
     std::size_t max_queue_size = 1);

--- a/include/web_video_server/multipart_stream.hpp
+++ b/include/web_video_server/multipart_stream.hpp
@@ -77,7 +77,6 @@ public:
 private:
   bool is_busy();
 
-private:
   const std::size_t max_queue_size_;
   async_web_server_cpp::HttpConnectionPtr connection_;
   std::string boundary_;

--- a/include/web_video_server/streamers/image_transport_streamer.hpp
+++ b/include/web_video_server/streamers/image_transport_streamer.hpp
@@ -81,7 +81,7 @@ protected:
   std::string qos_profile_name_;
 
   std::chrono::steady_clock::time_point last_frame_;
-  cv::Mat output_size_image;
+  cv::Mat output_size_image_;
   std::mutex send_mutex_;
 
 private:

--- a/include/web_video_server/streamers/image_transport_streamer.hpp
+++ b/include/web_video_server/streamers/image_transport_streamer.hpp
@@ -70,8 +70,10 @@ public:
 
 protected:
   virtual cv::Mat decode_image(const sensor_msgs::msg::Image::ConstSharedPtr & msg);
-  virtual void send_image(const cv::Mat &, const std::chrono::steady_clock::time_point & time) = 0;
-  virtual void initialize(const cv::Mat &);
+  virtual void send_image(
+    const cv::Mat & img,
+    const std::chrono::steady_clock::time_point & time) = 0;
+  virtual void initialize(const cv::Mat & img);
 
   image_transport::Subscriber image_sub_;
   int output_width_;

--- a/include/web_video_server/streamers/jpeg_streamers.hpp
+++ b/include/web_video_server/streamers/jpeg_streamers.hpp
@@ -59,7 +59,7 @@ public:
   ~MjpegStreamer();
 
 protected:
-  virtual void send_image(const cv::Mat &, const std::chrono::steady_clock::time_point & time);
+  virtual void send_image(const cv::Mat & img, const std::chrono::steady_clock::time_point & time);
 
 private:
   MultipartStream stream_;
@@ -86,7 +86,7 @@ public:
   ~JpegSnapshotStreamer();
 
 protected:
-  virtual void send_image(const cv::Mat &, const std::chrono::steady_clock::time_point & time);
+  virtual void send_image(const cv::Mat & img, const std::chrono::steady_clock::time_point & time);
 
 private:
   int quality_;

--- a/include/web_video_server/streamers/libav_streamer.hpp
+++ b/include/web_video_server/streamers/libav_streamer.hpp
@@ -78,8 +78,8 @@ public:
 
 protected:
   virtual void initialize_encoder() = 0;
-  virtual void send_image(const cv::Mat &, const std::chrono::steady_clock::time_point & time);
-  virtual void initialize(const cv::Mat &);
+  virtual void send_image(const cv::Mat & img, const std::chrono::steady_clock::time_point & time);
+  virtual void initialize(const cv::Mat & img);
   AVFormatContext * format_context_;
   const AVCodec * codec_;
   AVCodecContext * codec_context_;

--- a/include/web_video_server/streamers/png_streamers.hpp
+++ b/include/web_video_server/streamers/png_streamers.hpp
@@ -59,7 +59,7 @@ public:
   ~PngStreamer();
 
 protected:
-  virtual void send_image(const cv::Mat &, const std::chrono::steady_clock::time_point & time);
+  virtual void send_image(const cv::Mat & img, const std::chrono::steady_clock::time_point & time);
   virtual cv::Mat decode_image(const sensor_msgs::msg::Image::ConstSharedPtr & msg);
 
 private:
@@ -87,7 +87,7 @@ public:
   ~PngSnapshotStreamer();
 
 protected:
-  virtual void send_image(const cv::Mat &, const std::chrono::steady_clock::time_point & time);
+  virtual void send_image(const cv::Mat & img, const std::chrono::steady_clock::time_point & time);
   virtual cv::Mat decode_image(const sensor_msgs::msg::Image::ConstSharedPtr & msg);
 
 private:

--- a/include/web_video_server/streamers/ros_compressed_streamer.hpp
+++ b/include/web_video_server/streamers/ros_compressed_streamer.hpp
@@ -71,7 +71,7 @@ private:
   MultipartStream stream_;
   rclcpp::Subscription<sensor_msgs::msg::CompressedImage>::SharedPtr image_sub_;
   std::chrono::steady_clock::time_point last_frame_;
-  sensor_msgs::msg::CompressedImage::ConstSharedPtr last_msg;
+  sensor_msgs::msg::CompressedImage::ConstSharedPtr last_msg_;
   std::mutex send_mutex_;
   std::string qos_profile_name_;
 };

--- a/include/web_video_server/streamers/ros_compressed_streamer.hpp
+++ b/include/web_video_server/streamers/ros_compressed_streamer.hpp
@@ -63,11 +63,11 @@ public:
 
 protected:
   virtual void send_image(
-    const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg,
+    sensor_msgs::msg::CompressedImage::ConstSharedPtr msg,
     const std::chrono::steady_clock::time_point & time);
 
 private:
-  void image_callback(const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg);
+  void image_callback(sensor_msgs::msg::CompressedImage::ConstSharedPtr msg);
   MultipartStream stream_;
   rclcpp::Subscription<sensor_msgs::msg::CompressedImage>::SharedPtr image_sub_;
   std::chrono::steady_clock::time_point last_frame_;
@@ -100,11 +100,11 @@ public:
 
 protected:
   virtual void send_image(
-    const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg,
+    sensor_msgs::msg::CompressedImage::ConstSharedPtr msg,
     const std::chrono::steady_clock::time_point & time);
 
 private:
-  void image_callback(const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg);
+  void image_callback(sensor_msgs::msg::CompressedImage::ConstSharedPtr msg);
 
   rclcpp::Subscription<sensor_msgs::msg::CompressedImage>::SharedPtr image_sub_;
   std::string qos_profile_name_;

--- a/include/web_video_server/utils.hpp
+++ b/include/web_video_server/utils.hpp
@@ -42,6 +42,6 @@ namespace web_video_server
  * @param name The name of the QoS profile name.
  * @return An optional containing the matching QoS profile.
  */
-std::optional<rmw_qos_profile_t> get_qos_profile_from_name(const std::string name);
+std::optional<rmw_qos_profile_t> get_qos_profile_from_name(std::string name);
 
 }  // namespace web_video_server

--- a/include/web_video_server/web_video_server.hpp
+++ b/include/web_video_server/web_video_server.hpp
@@ -102,7 +102,6 @@ private:
   rclcpp::TimerBase::SharedPtr cleanup_timer_;
 
   // Parameters
-  int ros_threads_;
   double publish_rate_;
   int port_;
   std::string address_;

--- a/package.xml
+++ b/package.xml
@@ -38,7 +38,6 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend condition="$ROS_DISTRO == rolling">ament_cmake_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,7 @@
   <exec_depend>rclcpp_components</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_DISTRO == rolling">ament_cmake_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -36,7 +36,7 @@
   <exec_depend>rclcpp_components</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend condition="$ROS_DISTRO == rolling">ament_cmake_clang_tidy</test_depend>
+  <test_depend>ament_cmake_clang_tidy</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>

--- a/src/multipart_stream.cpp
+++ b/src/multipart_stream.cpp
@@ -136,7 +136,7 @@ bool MultipartStream::is_busy()
       }
     }
   }
-  return !(max_queue_size_ == 0 || pending_footers_.size() < max_queue_size_);
+  return max_queue_size_ != 0 && pending_footers_.size() >= max_queue_size_;
 }
 
 }  // namespace web_video_server

--- a/src/multipart_stream.cpp
+++ b/src/multipart_stream.cpp
@@ -76,7 +76,7 @@ void MultipartStream::send_part_header(
   snprintf(
     stamp, sizeof(stamp), "%.06lf",
     std::chrono::duration_cast<std::chrono::duration<double>>(time.time_since_epoch()).count());
-  std::shared_ptr<std::vector<async_web_server_cpp::HttpHeader>> headers(
+  const std::shared_ptr<std::vector<async_web_server_cpp::HttpHeader>> headers(
     new std::vector<async_web_server_cpp::HttpHeader>());
   headers->push_back(async_web_server_cpp::HttpHeader("Content-type", type));
   headers->push_back(async_web_server_cpp::HttpHeader("X-Timestamp", stamp));
@@ -88,7 +88,7 @@ void MultipartStream::send_part_header(
 
 void MultipartStream::send_part_footer(const std::chrono::steady_clock::time_point & time)
 {
-  std::shared_ptr<std::string> str(new std::string("\r\n--" + boundary_ + "\r\n"));
+  const std::shared_ptr<std::string> str(new std::string("\r\n--" + boundary_ + "\r\n"));
   PendingFooter pf;
   pf.timestamp = time;
   pf.contents = str;

--- a/src/streamer.cpp
+++ b/src/streamer.cpp
@@ -32,6 +32,8 @@
 
 #include <vector>
 #include <sstream>
+#include <string>
+#include <utility>
 
 #include "rclcpp/node.hpp"
 #include "rclcpp/logging.hpp"

--- a/src/streamers/h264_streamer.cpp
+++ b/src/streamers/h264_streamer.cpp
@@ -78,7 +78,7 @@ void H264Streamer::initialize_encoder()
   av_opt_set_int(codec_context_->priv_data, "g", 1, 0);
 
   // container format options
-  if (!strcmp(format_context_->oformat->name, "mp4")) {
+  if (strcmp(format_context_->oformat->name, "mp4") == 0) {
     // set up mp4 for streaming (instead of seekable file output)
     av_dict_set(&opt_, "movflags", "+frag_keyframe+empty_moov+faststart", 0);
   }

--- a/src/streamers/image_transport_streamer.cpp
+++ b/src/streamers/image_transport_streamer.cpp
@@ -126,7 +126,7 @@ void ImageTransportStreamerBase::start()
       // skip over topics with more than one type
       continue;
     }
-    auto & topic_name = topic_and_types.first;
+    const auto & topic_name = topic_and_types.first;
     if (topic_name == topic_ || (topic_name.find("/") == 0 && topic_name.substr(1) == topic_)) {
       inactive_ = false;
       break;
@@ -156,7 +156,7 @@ void ImageTransportStreamerBase::start()
 #pragma GCC diagnostic pop
 // NOLINTEND(clang-diagnostic-deprecated-declarations)
 
-void ImageTransportStreamerBase::initialize(const cv::Mat &)
+void ImageTransportStreamerBase::initialize(const cv::Mat & /*img*/)
 {
 }
 
@@ -202,8 +202,8 @@ void ImageTransportStreamerBase::image_callback(const sensor_msgs::msg::Image::C
 
     if (invert_) {
       // Rotate 180 degrees
-      cv::flip(img, img, false);
-      cv::flip(img, img, true);
+      cv::flip(img, img, 0);
+      cv::flip(img, img, 1);
     }
 
     std::scoped_lock lock(send_mutex_);  // protects output_size_image_
@@ -277,10 +277,9 @@ cv::Mat ImageTransportStreamerBase::decode_image(
       float_image *= (255 / max_val);
     }
     return float_image;
-  } else {
-    // Convert to OpenCV native BGR color
-    return cv_bridge::toCvCopy(msg, "bgr8")->image;
   }
+  // Convert to OpenCV native BGR color
+  return cv_bridge::toCvCopy(msg, "bgr8")->image;
 }
 
 std::vector<std::string> ImageTransportStreamerFactoryBase::get_available_topics(

--- a/src/streamers/image_transport_streamer.cpp
+++ b/src/streamers/image_transport_streamer.cpp
@@ -118,7 +118,7 @@ void ImageTransportStreamerBase::start()
     return;
   }
 
-  image_transport::TransportHints hints(node.get(), default_transport_);
+  const image_transport::TransportHints hints(node.get(), default_transport_);
   auto tnat = node->get_topic_names_and_types();
   inactive_ = true;
   for (auto topic_and_types : tnat) {
@@ -190,8 +190,8 @@ void ImageTransportStreamerBase::image_callback(const sensor_msgs::msg::Image::C
   cv::Mat img;
   try {
     img = decode_image(msg);
-    int input_width = img.cols;
-    int input_height = img.rows;
+    const int input_width = img.cols;
+    const int input_height = img.rows;
 
     if (output_width_ == -1) {
       output_width_ = input_width;
@@ -206,10 +206,10 @@ void ImageTransportStreamerBase::image_callback(const sensor_msgs::msg::Image::C
       cv::flip(img, img, 1);
     }
 
-    std::scoped_lock lock(send_mutex_);  // protects output_size_image_
+    const std::scoped_lock lock(send_mutex_);  // protects output_size_image_
     if (output_width_ != input_width || output_height_ != input_height) {
       cv::Mat img_resized;
-      cv::Size new_size(output_width_, output_height_);
+      const cv::Size new_size(output_width_, output_height_);
       cv::resize(img, img_resized, new_size);
       output_size_image_ = img_resized;
     } else {
@@ -243,7 +243,7 @@ void ImageTransportStreamerBase::try_send_image(
   rclcpp::Node & node)
 {
   try {
-    std::scoped_lock lock(send_mutex_);
+    const std::scoped_lock lock(send_mutex_);
     send_image(img, std::chrono::steady_clock::now());
   } catch (boost::system::system_error & e) {
     // happens when client disconnects
@@ -268,7 +268,7 @@ cv::Mat ImageTransportStreamerBase::decode_image(
 {
   if (msg->encoding.find("F") != std::string::npos) {
     // scale floating point images
-    cv::Mat float_image_bridge = cv_bridge::toCvCopy(msg, msg->encoding)->image;
+    const cv::Mat float_image_bridge = cv_bridge::toCvCopy(msg, msg->encoding)->image;
     cv::Mat_<float> float_image = float_image_bridge;
     double max_val;
     cv::minMaxIdx(float_image, 0, &max_val);

--- a/src/streamers/image_transport_streamer.cpp
+++ b/src/streamers/image_transport_streamer.cpp
@@ -104,6 +104,12 @@ ImageTransportStreamerBase::~ImageTransportStreamerBase()
 {
 }
 
+// We disable deprecation warnings for image_transport API usage
+// to maintain compatibility with older ROS 2 distributions.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// NOLINTBEGIN(clang-diagnostic-deprecated-declarations)
+
 void ImageTransportStreamerBase::start()
 {
   auto node = lock_node();
@@ -146,6 +152,9 @@ void ImageTransportStreamerBase::start()
     std::bind(&ImageTransportStreamerBase::image_callback, this, std::placeholders::_1),
     default_transport_, qos_profile.value());
 }
+
+#pragma GCC diagnostic pop
+// NOLINTEND(clang-diagnostic-deprecated-declarations)
 
 void ImageTransportStreamerBase::initialize(const cv::Mat &)
 {

--- a/src/streamers/image_transport_streamer.cpp
+++ b/src/streamers/image_transport_streamer.cpp
@@ -163,7 +163,7 @@ void ImageTransportStreamerBase::restream_frame(std::chrono::duration<double>/* 
     return;
   }
 
-  try_send_image(output_size_image, last_frame_, *node);
+  try_send_image(output_size_image_, last_frame_, *node);
 }
 
 void ImageTransportStreamerBase::image_callback(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
@@ -197,18 +197,18 @@ void ImageTransportStreamerBase::image_callback(const sensor_msgs::msg::Image::C
       cv::flip(img, img, true);
     }
 
-    std::scoped_lock lock(send_mutex_);  // protects output_size_image
+    std::scoped_lock lock(send_mutex_);  // protects output_size_image_
     if (output_width_ != input_width || output_height_ != input_height) {
       cv::Mat img_resized;
       cv::Size new_size(output_width_, output_height_);
       cv::resize(img, img_resized, new_size);
-      output_size_image = img_resized;
+      output_size_image_ = img_resized;
     } else {
-      output_size_image = img;
+      output_size_image_ = img;
     }
 
     if (!initialized_) {
-      initialize(output_size_image);
+      initialize(output_size_image_);
       initialized_ = true;
     }
 
@@ -225,7 +225,7 @@ void ImageTransportStreamerBase::image_callback(const sensor_msgs::msg::Image::C
     return;
   }
 
-  try_send_image(output_size_image, last_frame_, *node);
+  try_send_image(output_size_image_, last_frame_, *node);
 }
 
 void ImageTransportStreamerBase::try_send_image(

--- a/src/streamers/jpeg_streamers.cpp
+++ b/src/streamers/jpeg_streamers.cpp
@@ -37,6 +37,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <opencv2/core/mat.hpp>

--- a/src/streamers/jpeg_streamers.cpp
+++ b/src/streamers/jpeg_streamers.cpp
@@ -69,7 +69,7 @@ MjpegStreamer::MjpegStreamer(
 MjpegStreamer::~MjpegStreamer()
 {
   this->inactive_ = true;
-  std::scoped_lock lock(send_mutex_);  // protects send_image.
+  const std::scoped_lock lock(send_mutex_);  // protects send_image.
 }
 
 void MjpegStreamer::send_image(
@@ -106,7 +106,7 @@ JpegSnapshotStreamer::JpegSnapshotStreamer(
 JpegSnapshotStreamer::~JpegSnapshotStreamer()
 {
   this->inactive_ = true;
-  std::scoped_lock lock(send_mutex_);  // protects send_image.
+  const std::scoped_lock lock(send_mutex_);  // protects send_image.
 }
 
 void JpegSnapshotStreamer::send_image(

--- a/src/streamers/libav_streamer.cpp
+++ b/src/streamers/libav_streamer.cpp
@@ -83,8 +83,8 @@ LibavStreamerBase::LibavStreamerBase(
   const std::string & content_type)
 : ImageTransportStreamerBase(request, connection, node, logger_name), format_context_(0), codec_(0),
   codec_context_(0), video_stream_(0), opt_(0), frame_(0), sws_context_(0),
-  first_image_received_(false), first_image_time_(), format_name_(format_name),
-  codec_name_(codec_name), content_type_(content_type), io_buffer_(0)
+  first_image_received_(false), format_name_(format_name), codec_name_(codec_name),
+  content_type_(content_type), io_buffer_(0)
 {
   bitrate_ = request.get_query_param_value_or_default<int>("bitrate", 100000);
   qmin_ = request.get_query_param_value_or_default<int>("qmin", 10);
@@ -94,22 +94,20 @@ LibavStreamerBase::LibavStreamerBase(
 
 LibavStreamerBase::~LibavStreamerBase()
 {
-  if (codec_context_) {
+  if (codec_context_ != nullptr) {
     avcodec_free_context(&codec_context_);
   }
-  if (frame_) {
+  if (frame_ != nullptr) {
     av_frame_free(&frame_);
   }
-  if (io_buffer_) {
-    delete io_buffer_;
-  }
-  if (format_context_) {
-    if (format_context_->pb) {
+  delete io_buffer_;
+  if (format_context_ != nullptr) {
+    if (format_context_->pb != nullptr) {
       av_free(format_context_->pb);
     }
     avformat_free_context(format_context_);
   }
-  if (sws_context_) {
+  if (sws_context_ != nullptr) {
     sws_freeContext(sws_context_);
   }
 }
@@ -133,14 +131,14 @@ void LibavStreamerBase::initialize(const cv::Mat & /* img */)
 {
   // Load format
   format_context_ = avformat_alloc_context();
-  if (!format_context_) {
+  if (format_context_ == nullptr) {
     async_web_server_cpp::HttpReply::stock_reply(
       async_web_server_cpp::HttpReply::internal_server_error)(request_, connection_, NULL, NULL);
     throw std::runtime_error("Error allocating ffmpeg format context");
   }
 
   format_context_->oformat = av_guess_format(format_name_.c_str(), NULL, NULL);
-  if (!format_context_->oformat) {
+  if (format_context_->oformat == nullptr) {
     async_web_server_cpp::HttpReply::stock_reply(
       async_web_server_cpp::HttpReply::internal_server_error)(request_, connection_, NULL, NULL);
     throw std::runtime_error("Error looking up output format");
@@ -152,7 +150,7 @@ void LibavStreamerBase::initialize(const cv::Mat & /* img */)
   AVIOContext * io_ctx = avio_alloc_context(
     io_buffer_, io_buffer_size, AVIO_FLAG_WRITE,
     &connection_, NULL, dispatch_output_packet, NULL);
-  if (!io_ctx) {
+  if (io_ctx == nullptr) {
     async_web_server_cpp::HttpReply::stock_reply(
       async_web_server_cpp::HttpReply::internal_server_error)(request_, connection_, NULL, NULL);
     throw std::runtime_error("Error setting up IO context");
@@ -167,13 +165,13 @@ void LibavStreamerBase::initialize(const cv::Mat & /* img */)
   } else {
     codec_ = avcodec_find_encoder_by_name(codec_name_.c_str());
   }
-  if (!codec_) {
+  if (codec_ == nullptr) {
     async_web_server_cpp::HttpReply::stock_reply(
       async_web_server_cpp::HttpReply::internal_server_error)(request_, connection_, NULL, NULL);
     throw std::runtime_error("Error looking up codec");
   }
   video_stream_ = avformat_new_stream(format_context_, codec_);
-  if (!video_stream_) {
+  if (video_stream_ == nullptr) {
     async_web_server_cpp::HttpReply::stock_reply(
       async_web_server_cpp::HttpReply::internal_server_error)(request_, connection_, NULL, NULL);
     throw std::runtime_error("Error creating video stream");
@@ -271,12 +269,12 @@ void LibavStreamerBase::send_image(
     img.data, input_coding_format, output_width_, output_height_, 1);
 
   // Convert from opencv to libav
-  if (!sws_context_) {
+  if (sws_context_ == nullptr) {
     static int sws_flags = SWS_BICUBIC;
     sws_context_ = sws_getContext(
       output_width_, output_height_, input_coding_format, output_width_,
       output_height_, codec_context_->pix_fmt, sws_flags, NULL, NULL, NULL);
-    if (!sws_context_) {
+    if (sws_context_ == nullptr) {
       throw std::runtime_error("Could not initialize the conversion context");
     }
   }
@@ -321,13 +319,13 @@ void LibavStreamerBase::send_image(
     }
     pkt->dts = pkt->pts;
 
-    if (pkt->flags & AV_PKT_FLAG_KEY) {
+    if ((pkt->flags & AV_PKT_FLAG_KEY) != 0) {
       pkt->flags |= AV_PKT_FLAG_KEY;
     }
 
     pkt->stream_index = video_stream_->index;
 
-    if (av_write_frame(format_context_, pkt)) {
+    if (av_write_frame(format_context_, pkt) < 0) {
       throw std::runtime_error("Error when writing frame");
     }
   }

--- a/src/streamers/libav_streamer.cpp
+++ b/src/streamers/libav_streamer.cpp
@@ -115,7 +115,7 @@ LibavStreamerBase::~LibavStreamerBase()
 }
 
 // output callback for ffmpeg IO context
-#if LIBAVFORMAT_VERSION_MAJOR < 61
+#if LIBAVFORMAT_VERSION_MAJOR < 61  // NOLINT(misc-include-cleaner)
 static int dispatch_output_packet(void * opaque, uint8_t * buffer, int buffer_size)
 #else
 static int dispatch_output_packet(void * opaque, const uint8_t * buffer, int buffer_size)

--- a/src/streamers/libav_streamer.cpp
+++ b/src/streamers/libav_streamer.cpp
@@ -122,7 +122,7 @@ static int dispatch_output_packet(void * opaque, const uint8_t * buffer, int buf
 #endif
 {
   async_web_server_cpp::HttpConnectionPtr connection =
-    *((async_web_server_cpp::HttpConnectionPtr *) opaque);
+    *(static_cast<async_web_server_cpp::HttpConnectionPtr *>(opaque));
   std::vector<uint8_t> encoded_frame;
   encoded_frame.assign(buffer, buffer + buffer_size);
   connection->write_and_clear(encoded_frame);
@@ -284,7 +284,7 @@ void LibavStreamerBase::send_image(
 
   sws_scale(
     sws_context_,
-    (const uint8_t * const *)raw_frame->data, raw_frame->linesize, 0,
+    static_cast<const uint8_t * const *>(raw_frame->data), raw_frame->linesize, 0,
     output_height_, frame_->data, frame_->linesize);
 
   av_frame_free(&raw_frame);
@@ -315,7 +315,7 @@ void LibavStreamerBase::send_image(
     double seconds = std::chrono::duration_cast<std::chrono::duration<double>>(
       time - first_image_time_).count();
     // Encode video at 1/0.95 to minimize delay
-    pkt->pts = (int64_t)(seconds / av_q2d(video_stream_->time_base) * 0.95);
+    pkt->pts = static_cast<int64_t>(seconds / av_q2d(video_stream_->time_base) * 0.95);
     if (pkt->pts <= 0) {
       pkt->pts = 1;
     }

--- a/src/streamers/libav_streamer.cpp
+++ b/src/streamers/libav_streamer.cpp
@@ -112,7 +112,8 @@ LibavStreamerBase::~LibavStreamerBase()
   }
 }
 
-namespace {
+namespace
+{
 // output callback for ffmpeg IO context
 #if LIBAVFORMAT_VERSION_MAJOR < 61  // NOLINT(misc-include-cleaner)
 int dispatch_output_packet(void * opaque, uint8_t * buffer, int buffer_size)

--- a/src/streamers/libav_streamer.cpp
+++ b/src/streamers/libav_streamer.cpp
@@ -112,20 +112,22 @@ LibavStreamerBase::~LibavStreamerBase()
   }
 }
 
+namespace {
 // output callback for ffmpeg IO context
 #if LIBAVFORMAT_VERSION_MAJOR < 61  // NOLINT(misc-include-cleaner)
-static int dispatch_output_packet(void * opaque, uint8_t * buffer, int buffer_size)
+int dispatch_output_packet(void * opaque, uint8_t * buffer, int buffer_size)
 #else
-static int dispatch_output_packet(void * opaque, const uint8_t * buffer, int buffer_size)
+int dispatch_output_packet(void * opaque, const uint8_t * buffer, int buffer_size)
 #endif
 {
-  async_web_server_cpp::HttpConnectionPtr connection =
+  const async_web_server_cpp::HttpConnectionPtr connection =
     *(static_cast<async_web_server_cpp::HttpConnectionPtr *>(opaque));
   std::vector<uint8_t> encoded_frame;
   encoded_frame.assign(buffer, buffer + buffer_size);
   connection->write_and_clear(encoded_frame);
   return 0;
 }
+}  // namespace
 
 void LibavStreamerBase::initialize(const cv::Mat & /* img */)
 {
@@ -145,7 +147,7 @@ void LibavStreamerBase::initialize(const cv::Mat & /* img */)
   }
 
   // Set up custom IO callback.
-  size_t io_buffer_size = 3 * 1024;    // 3M seen elsewhere and adjudged good
+  const size_t io_buffer_size = 3 * 1024;    // 3M seen elsewhere and adjudged good
   io_buffer_ = new unsigned char[io_buffer_size];
   AVIOContext * io_ctx = avio_alloc_context(
     io_buffer_, io_buffer_size, AVIO_FLAG_WRITE,
@@ -255,13 +257,13 @@ void LibavStreamerBase::send_image(
   const cv::Mat & img,
   const std::chrono::steady_clock::time_point & time)
 {
-  std::scoped_lock lock(encode_mutex_);
+  const std::scoped_lock lock(encode_mutex_);
   if (!first_image_received_) {
     first_image_received_ = true;
     first_image_time_ = time;
   }
 
-  AVPixelFormat input_coding_format = AV_PIX_FMT_BGR24;
+  const AVPixelFormat input_coding_format = AV_PIX_FMT_BGR24;
 
   AVFrame * raw_frame = av_frame_alloc();
   av_image_fill_arrays(
@@ -270,7 +272,7 @@ void LibavStreamerBase::send_image(
 
   // Convert from opencv to libav
   if (sws_context_ == nullptr) {
-    static int sws_flags = SWS_BICUBIC;
+    static const int sws_flags = SWS_BICUBIC;
     sws_context_ = sws_getContext(
       output_width_, output_height_, input_coding_format, output_width_,
       output_height_, codec_context_->pix_fmt, sws_flags, NULL, NULL, NULL);
@@ -310,7 +312,7 @@ void LibavStreamerBase::send_image(
   }
 
   if (got_packet) {
-    double seconds = std::chrono::duration_cast<std::chrono::duration<double>>(
+    const double seconds = std::chrono::duration_cast<std::chrono::duration<double>>(
       time - first_image_time_).count();
     // Encode video at 1/0.95 to minimize delay
     pkt->pts = static_cast<int64_t>(seconds / av_q2d(video_stream_->time_base) * 0.95);

--- a/src/streamers/png_streamers.cpp
+++ b/src/streamers/png_streamers.cpp
@@ -74,7 +74,7 @@ PngStreamer::PngStreamer(
 PngStreamer::~PngStreamer()
 {
   this->inactive_ = true;
-  std::scoped_lock lock(send_mutex_);  // protects send_image.
+  const std::scoped_lock lock(send_mutex_);  // protects send_image.
 }
 
 cv::Mat PngStreamer::decode_image(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
@@ -121,7 +121,7 @@ PngSnapshotStreamer::PngSnapshotStreamer(
 PngSnapshotStreamer::~PngSnapshotStreamer()
 {
   this->inactive_ = true;
-  std::scoped_lock lock(send_mutex_);  // protects send_image.
+  const std::scoped_lock lock(send_mutex_);  // protects send_image.
 }
 
 cv::Mat PngSnapshotStreamer::decode_image(const sensor_msgs::msg::Image::ConstSharedPtr & msg)

--- a/src/streamers/png_streamers.cpp
+++ b/src/streamers/png_streamers.cpp
@@ -82,10 +82,9 @@ cv::Mat PngStreamer::decode_image(const sensor_msgs::msg::Image::ConstSharedPtr 
   // Handle alpha values since PNG supports it
   if (sensor_msgs::image_encodings::hasAlpha(msg->encoding)) {
     return cv_bridge::toCvCopy(msg, "bgra8")->image;
-  } else {
-    // Use the normal decode otherwise
-    return ImageTransportStreamerBase::decode_image(msg);
   }
+  // Use the normal decode otherwise
+  return ImageTransportStreamerBase::decode_image(msg);
 }
 
 void PngStreamer::send_image(
@@ -130,10 +129,9 @@ cv::Mat PngSnapshotStreamer::decode_image(const sensor_msgs::msg::Image::ConstSh
   // Handle alpha values since PNG supports it
   if (sensor_msgs::image_encodings::hasAlpha(msg->encoding)) {
     return cv_bridge::toCvCopy(msg, "bgra8")->image;
-  } else {
-    // Use the normal decode otherwise
-    return ImageTransportStreamerBase::decode_image(msg);
   }
+  // Use the normal decode otherwise
+  return ImageTransportStreamerBase::decode_image(msg);
 }
 
 void PngSnapshotStreamer::send_image(

--- a/src/streamers/ros_compressed_streamer.cpp
+++ b/src/streamers/ros_compressed_streamer.cpp
@@ -30,6 +30,7 @@
 
 #include "web_video_server/streamers/ros_compressed_streamer.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <exception>
@@ -125,18 +126,14 @@ bool has_compressed_topic(rclcpp::Node & node, const std::string & topic)
 {
   const auto compressed_topic_name = topic + "/compressed";
   const auto tnat = node.get_topic_names_and_types();
-  for (const auto & topic_and_types : tnat) {
-    if (topic_and_types.second.size() > 1) {
-      continue;
-    }
-    const auto & topic_name = topic_and_types.first;
-    if (topic_name == compressed_topic_name ||
-      (topic_name.rfind('/') == 0 && topic_name.substr(1) == compressed_topic_name))
-    {
-      return true;
-    }
-  }
-  return false;
+  return std::any_of(tnat.begin(), tnat.end(), [&](const auto & topic_and_types) {
+             if (topic_and_types.second.size() > 1) {
+               return false;
+             }
+             const auto & topic_name = topic_and_types.first;
+             return topic_name == compressed_topic_name ||
+                    (topic_name.rfind('/') == 0 && topic_name.substr(1) == compressed_topic_name);
+  });
 }
 
 std::vector<std::string> collect_compressed_topics(rclcpp::Node & node)

--- a/src/streamers/ros_compressed_streamer.cpp
+++ b/src/streamers/ros_compressed_streamer.cpp
@@ -126,13 +126,14 @@ bool has_compressed_topic(rclcpp::Node & node, const std::string & topic)
 {
   const auto compressed_topic_name = topic + "/compressed";
   const auto tnat = node.get_topic_names_and_types();
-  return std::any_of(tnat.begin(), tnat.end(), [&](const auto & topic_and_types) {
-             if (topic_and_types.second.size() > 1) {
-               return false;
-             }
-             const auto & topic_name = topic_and_types.first;
-             return topic_name == compressed_topic_name ||
-                    (topic_name.rfind('/') == 0 && topic_name.substr(1) == compressed_topic_name);
+  return std::any_of(
+    tnat.begin(), tnat.end(), [&](const auto & topic_and_types) {
+      if (topic_and_types.second.size() > 1) {
+        return false;
+      }
+      const auto & topic_name = topic_and_types.first;
+      return topic_name == compressed_topic_name ||
+             (topic_name.rfind('/') == 0 && topic_name.substr(1) == compressed_topic_name);
   });
 }
 

--- a/src/streamers/ros_compressed_streamer.cpp
+++ b/src/streamers/ros_compressed_streamer.cpp
@@ -171,7 +171,7 @@ RosCompressedStreamer::RosCompressedStreamer(
 RosCompressedStreamer::~RosCompressedStreamer()
 {
   this->inactive_ = true;
-  std::scoped_lock lock(send_mutex_);  // protects send_image.
+  const std::scoped_lock lock(send_mutex_);  // protects send_image.
 }
 
 void RosCompressedStreamer::start()
@@ -194,7 +194,7 @@ void RosCompressedStreamer::restream_frame(std::chrono::duration<double> max_age
   }
 
   if (last_frame_ + max_age < std::chrono::steady_clock::now()) {
-    std::scoped_lock lock(send_mutex_);
+    const std::scoped_lock lock(send_mutex_);
     // don't update last_frame, it may remain an old value.
     send_image(last_msg_, std::chrono::steady_clock::now());
   }
@@ -239,7 +239,7 @@ void RosCompressedStreamer::send_image(
 void RosCompressedStreamer::image_callback(
   const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg)
 {
-  std::scoped_lock lock(send_mutex_);  // protects last_msg_ and last_frame_
+  const std::scoped_lock lock(send_mutex_);  // protects last_msg_ and last_frame_
   last_msg_ = msg;
   last_frame_ = std::chrono::steady_clock::now();
   send_image(last_msg_, last_frame_);
@@ -259,7 +259,7 @@ std::shared_ptr<StreamerInterface> RosCompressedStreamerFactory::create_streamer
     return nullptr;
   }
 
-  std::string topic = request.get_query_param_value_or_default("topic", "");
+  const std::string topic = request.get_query_param_value_or_default("topic", "");
   if (!has_compressed_topic(*node_locked, topic)) {
     RCLCPP_WARN(
       node_locked->get_logger().get_child("RosCompressedStreamerFactory"),
@@ -383,7 +383,7 @@ RosCompressedSnapshotStreamerFactory::create_streamer(
     return nullptr;
   }
 
-  std::string topic = request.get_query_param_value_or_default("topic", "");
+  const std::string topic = request.get_query_param_value_or_default("topic", "");
   if (!has_compressed_topic(*node_locked, topic)) {
     RCLCPP_WARN(
       node_locked->get_logger().get_child("RosCompressedSnapshotStreamerFactory"),

--- a/src/streamers/ros_compressed_streamer.cpp
+++ b/src/streamers/ros_compressed_streamer.cpp
@@ -192,14 +192,14 @@ void RosCompressedStreamer::start()
 
 void RosCompressedStreamer::restream_frame(std::chrono::duration<double> max_age)
 {
-  if (inactive_ || (last_msg == 0)) {
+  if (inactive_ || (last_msg_ == 0)) {
     return;
   }
 
   if (last_frame_ + max_age < std::chrono::steady_clock::now()) {
     std::scoped_lock lock(send_mutex_);
     // don't update last_frame, it may remain an old value.
-    send_image(last_msg, std::chrono::steady_clock::now());
+    send_image(last_msg_, std::chrono::steady_clock::now());
   }
 }
 
@@ -242,10 +242,10 @@ void RosCompressedStreamer::send_image(
 void RosCompressedStreamer::image_callback(
   const sensor_msgs::msg::CompressedImage::ConstSharedPtr msg)
 {
-  std::scoped_lock lock(send_mutex_);  // protects last_msg and last_frame
-  last_msg = msg;
+  std::scoped_lock lock(send_mutex_);  // protects last_msg_ and last_frame_
+  last_msg_ = msg;
   last_frame_ = std::chrono::steady_clock::now();
-  send_image(last_msg, last_frame_);
+  send_image(last_msg_, last_frame_);
 }
 
 

--- a/src/streamers/ros_compressed_streamer.cpp
+++ b/src/streamers/ros_compressed_streamer.cpp
@@ -132,9 +132,11 @@ bool has_compressed_topic(rclcpp::Node & node, const std::string & topic)
         return false;
       }
       const auto & topic_name = topic_and_types.first;
+      /* *INDENT-OFF* */
       return topic_name == compressed_topic_name ||
              (topic_name.rfind('/') == 0 && topic_name.substr(1) == compressed_topic_name);
-  });
+      /* *INDENT-ON* */
+    });
 }
 
 std::vector<std::string> collect_compressed_topics(rclcpp::Node & node)

--- a/src/streamers/vp8_streamer.cpp
+++ b/src/streamers/vp8_streamer.cpp
@@ -80,7 +80,7 @@ void Vp8Streamer::initialize_encoder()
   }
 
   // Buffering settings
-  int bufsize = 10;
+  const int bufsize = 10;
   codec_context_->rc_buffer_size = bufsize;
   codec_context_->rc_initial_buffer_occupancy = bufsize;  // bitrate/3;
   av_opt_set_int(codec_context_->priv_data, "bufsize", bufsize, 0);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -42,13 +42,14 @@ std::optional<rmw_qos_profile_t> get_qos_profile_from_name(const std::string nam
 {
   if (name == "default") {
     return rmw_qos_profile_default;
-  } else if (name == "system_default") {
-    return rmw_qos_profile_system_default;
-  } else if (name == "sensor_data") {
-    return rmw_qos_profile_sensor_data;
-  } else {
-    return std::nullopt;
   }
+  if (name == "system_default") {
+    return rmw_qos_profile_system_default;
+  }
+  if (name == "sensor_data") {
+    return rmw_qos_profile_sensor_data;
+  }
+  return std::nullopt;
 }
 
 }  // namespace web_video_server

--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -156,7 +156,7 @@ WebVideoServer::~WebVideoServer()
 
 void WebVideoServer::restream_frames(std::chrono::duration<double> max_age)
 {
-  std::scoped_lock lock(streamers_mutex_);
+  const std::scoped_lock lock(streamers_mutex_);
 
   for (auto & streamer : streamers_) {
     streamer->restream_frame(max_age);
@@ -165,7 +165,7 @@ void WebVideoServer::restream_frames(std::chrono::duration<double> max_age)
 
 void WebVideoServer::cleanup_inactive_streams()
 {
-  std::unique_lock lock(streamers_mutex_, std::try_to_lock);
+  const std::unique_lock lock(streamers_mutex_, std::try_to_lock);
   if (lock) {
     auto new_end = std::partition(
       streamers_.begin(), streamers_.end(),
@@ -201,12 +201,12 @@ bool WebVideoServer::handle_stream(
   async_web_server_cpp::HttpConnectionPtr connection, const char * begin,
   const char * end)
 {
-  std::string type = request.get_query_param_value_or_default("type", default_stream_type_);
+  const std::string type = request.get_query_param_value_or_default("type", default_stream_type_);
   if (streamer_factories_.find(type) != streamer_factories_.end()) {
-    std::shared_ptr<StreamerInterface> streamer = streamer_factories_[type]->create_streamer(
+    const std::shared_ptr<StreamerInterface> streamer = streamer_factories_[type]->create_streamer(
       request, connection, weak_from_this());
     streamer->start();
-    std::scoped_lock lock(streamers_mutex_);
+    const std::scoped_lock lock(streamers_mutex_);
     streamers_.push_back(streamer);
   } else {
     async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found)(
@@ -220,13 +220,13 @@ bool WebVideoServer::handle_snapshot(
   async_web_server_cpp::HttpConnectionPtr connection, const char * begin,
   const char * end)
 {
-  std::string type = request.get_query_param_value_or_default("type", default_snapshot_type_);
+  const std::string type = request.get_query_param_value_or_default("type", default_snapshot_type_);
   if (snapshot_streamer_factories_.find(type) != snapshot_streamer_factories_.end()) {
-    std::shared_ptr<StreamerInterface> streamer =
+    const std::shared_ptr<StreamerInterface> streamer =
       snapshot_streamer_factories_[type]->create_streamer(
       request, connection, weak_from_this());
     streamer->start();
-    std::scoped_lock lock(streamers_mutex_);
+    const std::scoped_lock lock(streamers_mutex_);
     streamers_.push_back(streamer);
   } else {
     async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found)(
@@ -240,9 +240,9 @@ bool WebVideoServer::handle_stream_viewer(
   async_web_server_cpp::HttpConnectionPtr connection, const char * begin,
   const char * end)
 {
-  std::string type = request.get_query_param_value_or_default("type", default_stream_type_);
+  const std::string type = request.get_query_param_value_or_default("type", default_stream_type_);
   if (streamer_factories_.find(type) != streamer_factories_.end()) {
-    std::string topic = request.get_query_param_value_or_default("topic", "");
+    const std::string topic = request.get_query_param_value_or_default("topic", "");
 
     async_web_server_cpp::HttpReply::builder(async_web_server_cpp::HttpReply::ok)
     .header("Connection", "close")
@@ -274,7 +274,7 @@ bool WebVideoServer::handle_list_streams(
 
   for (const auto & factory_pair : streamer_factories_) {
     RCLCPP_DEBUG(get_logger(), "Getting topics from factory: %s", factory_pair.first.c_str());
-    std::vector<std::string> factory_topics =
+    const std::vector<std::string> factory_topics =
       factory_pair.second->get_available_topics(*this);
     RCLCPP_DEBUG(
       get_logger(), "Factory %s returned %zu topics",
@@ -288,7 +288,7 @@ bool WebVideoServer::handle_list_streams(
 
   for (const auto & factory_pair : snapshot_streamer_factories_) {
     RCLCPP_DEBUG(get_logger(), "Getting topics from factory: %s", factory_pair.first.c_str());
-    std::vector<std::string> factory_topics =
+    const std::vector<std::string> factory_topics =
       factory_pair.second->get_available_topics(*this);
     RCLCPP_DEBUG(
       get_logger(), "Factory %s returned %zu topics",

--- a/src/web_video_server_node.cpp
+++ b/src/web_video_server_node.cpp
@@ -30,7 +30,8 @@
 
 #include <memory>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/executors/multi_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
 
 #include "web_video_server/web_video_server.hpp"
 


### PR DESCRIPTION
This PR adds clang-tidy check using `ament_clang_tidy`. The check is disabled by default and can be enabled using `ENABLE_CLANG_TIDY` CMake option. Two reasons behind it:
- The check is quite slow (~100 seconds in CI)
- In CI, we enable the check only for Rolling distribution to avoid having to deal with multiple different versions of clang-tidy

The motivation behind clang-tidy was the [readability-identifier-naming](https://releases.llvm.org/18.1.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability/identifier-naming.html) check which codifies naming conventions as requested in [this discussion](https://github.com/RobotWebTools/web_video_server/pull/192#discussion_r2500030232)

The few other basic checks like `google-*`, `misc-*`, `readability-*` seem to completely supersede `cpplint` so I removed it.
