### PR TITLE
fix: Use new image_transport API when applicable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,10 @@ if(${cv_bridge_VERSION} VERSION_LESS "3.3.0")
   add_compile_definitions(CV_BRIDGE_USES_OLD_HEADERS)
 endif()
 
+if(${image_transport_VERSION} VERSION_LESS "6.4.0")
+  add_compile_definitions(IMAGE_TRANSPORT_USES_OLD_API)
+endif()
+
 ## Declare a cpp library
 add_library(${PROJECT_NAME} SHARED
   src/web_video_server.cpp

--- a/include/web_video_server/utils.hpp
+++ b/include/web_video_server/utils.hpp
@@ -32,7 +32,7 @@
 #include <string>
 #include <optional>
 
-#include "rmw/types.h"
+#include "rclcpp/qos.hpp"
 
 namespace web_video_server
 {
@@ -42,6 +42,6 @@ namespace web_video_server
  * @param name The name of the QoS profile name.
  * @return An optional containing the matching QoS profile.
  */
-std::optional<rmw_qos_profile_t> get_qos_profile_from_name(std::string name);
+std::optional<rclcpp::QoS> get_qos_profile_from_name(std::string name);
 
 }  // namespace web_video_server

--- a/include/web_video_server/utils.hpp
+++ b/include/web_video_server/utils.hpp
@@ -39,9 +39,9 @@ namespace web_video_server
 
 /**
  * @brief Gets a QoS profile given an input name, if valid.
- * @param name The name of the QoS profile name.
+ * @param name The name of the QoS profile.
  * @return An optional containing the matching QoS profile.
  */
-std::optional<rclcpp::QoS> get_qos_profile_from_name(std::string name);
+std::optional<rclcpp::QoS> get_qos_profile_from_name(const std::string & name);
 
 }  // namespace web_video_server

--- a/src/streamers/image_transport_streamer.cpp
+++ b/src/streamers/image_transport_streamer.cpp
@@ -155,7 +155,7 @@ void ImageTransportStreamerBase::start()
   image_sub_ = image_transport::create_subscription(
     node.get(), topic_,
     std::bind(&ImageTransportStreamerBase::image_callback, this, std::placeholders::_1),
-    default_transport_, qos_profile.get_rmw_qos_profile());
+    default_transport_, qos_profile.value().get_rmw_qos_profile());
 #else
   image_sub_ = image_transport::create_subscription(
     *node.get(), topic_,

--- a/src/streamers/image_transport_streamer.cpp
+++ b/src/streamers/image_transport_streamer.cpp
@@ -118,7 +118,7 @@ void ImageTransportStreamerBase::start()
     return;
   }
 
-  const image_transport::TransportHints hints(node.get(), default_transport_);
+  const image_transport::TransportHints hints(*node.get(), default_transport_);
   auto tnat = node->get_topic_names_and_types();
   inactive_ = true;
   for (auto topic_and_types : tnat) {
@@ -139,7 +139,7 @@ void ImageTransportStreamerBase::start()
     qos_profile_name_.c_str());
   auto qos_profile = get_qos_profile_from_name(qos_profile_name_);
   if (!qos_profile) {
-    qos_profile = rmw_qos_profile_default;
+    qos_profile = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
     RCLCPP_ERROR(
       logger_,
       "Invalid QoS profile %s specified. Using default profile.",
@@ -148,7 +148,7 @@ void ImageTransportStreamerBase::start()
 
   // Create subscriber
   image_sub_ = image_transport::create_subscription(
-    node.get(), topic_,
+    *node.get(), topic_,
     std::bind(&ImageTransportStreamerBase::image_callback, this, std::placeholders::_1),
     default_transport_, qos_profile.value());
 }

--- a/src/streamers/image_transport_streamer.cpp
+++ b/src/streamers/image_transport_streamer.cpp
@@ -118,7 +118,11 @@ void ImageTransportStreamerBase::start()
     return;
   }
 
+#ifdef IMAGE_TRANSPORT_USES_OLD_API
+  const image_transport::TransportHints hints(node.get(), default_transport_);
+#else
   const image_transport::TransportHints hints(*node.get(), default_transport_);
+#endif
   auto tnat = node->get_topic_names_and_types();
   inactive_ = true;
   for (auto topic_and_types : tnat) {
@@ -147,10 +151,17 @@ void ImageTransportStreamerBase::start()
   }
 
   // Create subscriber
+#ifdef IMAGE_TRANSPORT_USES_OLD_API
+  image_sub_ = image_transport::create_subscription(
+    node.get(), topic_,
+    std::bind(&ImageTransportStreamerBase::image_callback, this, std::placeholders::_1),
+    default_transport_, qos_profile.get_rmw_qos_profile());
+#else
   image_sub_ = image_transport::create_subscription(
     *node.get(), topic_,
     std::bind(&ImageTransportStreamerBase::image_callback, this, std::placeholders::_1),
     default_transport_, qos_profile.value());
+#endif
 }
 
 #pragma GCC diagnostic pop

--- a/src/streamers/image_transport_streamer.cpp
+++ b/src/streamers/image_transport_streamer.cpp
@@ -52,7 +52,6 @@
 #include "async_web_server_cpp/http_connection.hpp"
 #include "async_web_server_cpp/http_request.hpp"
 #include "image_transport/image_transport.hpp"
-#include "image_transport/transport_hints.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/logging.hpp"
 #include "rmw/qos_profiles.h"
@@ -118,11 +117,6 @@ void ImageTransportStreamerBase::start()
     return;
   }
 
-#ifdef IMAGE_TRANSPORT_USES_OLD_API
-  const image_transport::TransportHints hints(node.get(), default_transport_);
-#else
-  const image_transport::TransportHints hints(*node.get(), default_transport_);
-#endif
   auto tnat = node->get_topic_names_and_types();
   inactive_ = true;
   for (auto topic_and_types : tnat) {

--- a/src/streamers/ros_compressed_streamer.cpp
+++ b/src/streamers/ros_compressed_streamer.cpp
@@ -84,12 +84,10 @@ rclcpp::QoS make_compressed_qos(
       logger,
       "Invalid QoS profile %s specified. Using default profile.",
       qos_profile_name.c_str());
-    qos_profile = rmw_qos_profile_default;
+    qos_profile = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
   }
 
-  return rclcpp::QoS(
-    rclcpp::QoSInitialization(qos_profile.value().history, 1),
-    qos_profile.value());
+  return qos_profile.value();
 }
 
 std::optional<std::string> resolve_content_type(

--- a/src/streamers/ros_compressed_streamer.cpp
+++ b/src/streamers/ros_compressed_streamer.cpp
@@ -87,7 +87,9 @@ rclcpp::QoS make_compressed_qos(
     qos_profile = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
   }
 
-  return qos_profile.value();
+  auto qos = qos_profile.value();
+  qos.keep_last(1);
+  return qos;
 }
 
 std::optional<std::string> resolve_content_type(

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -34,12 +34,11 @@
 
 #include "rclcpp/qos.hpp"
 #include "rmw/qos_profiles.h"
-#include "rmw/types.h"
 
 namespace web_video_server
 {
 
-std::optional<rclcpp::QoS> get_qos_profile_from_name(const std::string name)
+std::optional<rclcpp::QoS> get_qos_profile_from_name(const std::string & name)
 {
   if (name == "default") {
     return rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -32,22 +32,23 @@
 #include <optional>
 #include <string>
 
+#include "rclcpp/qos.hpp"
 #include "rmw/qos_profiles.h"
 #include "rmw/types.h"
 
 namespace web_video_server
 {
 
-std::optional<rmw_qos_profile_t> get_qos_profile_from_name(const std::string name)
+std::optional<rclcpp::QoS> get_qos_profile_from_name(const std::string name)
 {
   if (name == "default") {
-    return rmw_qos_profile_default;
+    return rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
   }
   if (name == "system_default") {
-    return rmw_qos_profile_system_default;
+    return rclcpp::SystemDefaultsQoS();
   }
   if (name == "sensor_data") {
-    return rmw_qos_profile_sensor_data;
+    return rclcpp::SensorDataQoS();
   }
   return std::nullopt;
 }


### PR DESCRIPTION
**Public API Changes**
None


**Description**
This fixes the build on rolling which recently removed the old API entirely.

The CI fails due to clang-tidy errors which I'll fix in another PR
